### PR TITLE
Fix user password handling

### DIFF
--- a/src/main/java/com/example/scheduletracker/config/SecurityConfig.java
+++ b/src/main/java/com/example/scheduletracker/config/SecurityConfig.java
@@ -5,6 +5,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -33,5 +35,10 @@ public class SecurityConfig {
                 .httpBasic(Customizer.withDefaults());
 
         return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/example/scheduletracker/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/example/scheduletracker/service/impl/UserServiceImpl.java
@@ -5,6 +5,7 @@ import com.example.scheduletracker.entity.User;
 import com.example.scheduletracker.repository.UserRepository;
 import com.example.scheduletracker.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -13,9 +14,11 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
     private final UserRepository repo;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     public User save(User user) {
+        user.setPassword(passwordEncoder.encode(user.getPassword()));
         return repo.save(user);
     }
 

--- a/src/test/java/com/example/scheduletracker/service/UserServiceImplTest.java
+++ b/src/test/java/com/example/scheduletracker/service/UserServiceImplTest.java
@@ -1,0 +1,45 @@
+package com.example.scheduletracker.service;
+
+import com.example.scheduletracker.entity.User;
+import com.example.scheduletracker.repository.UserRepository;
+import com.example.scheduletracker.service.impl.UserServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceImplTest {
+
+    @Mock
+    private UserRepository repo;
+
+    private UserServiceImpl service;
+
+    @BeforeEach
+    void setup() {
+        service = new UserServiceImpl(repo, new BCryptPasswordEncoder());
+    }
+
+    @Test
+    void saveEncodesPassword() {
+        when(repo.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        User u = User.builder()
+                .username("alice")
+                .password("secret")
+                .role(User.Role.STUDENT)
+                .build();
+
+        User saved = service.save(u);
+
+        assertNotEquals("secret", saved.getPassword());
+        assertTrue(new BCryptPasswordEncoder().matches("secret", saved.getPassword()));
+    }
+}


### PR DESCRIPTION
## Summary
- hash passwords on save
- expose a PasswordEncoder bean
- test that passwords are encoded

## Testing
- `mvnw test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_683f4048dda08326a581b977a19c26a4