### PR TITLE
Add security test for UserController

### DIFF
--- a/src/test/java/com/example/scheduletracker/controller/UserControllerSecurityTest.java
+++ b/src/test/java/com/example/scheduletracker/controller/UserControllerSecurityTest.java
@@ -1,0 +1,31 @@
+package com.example.scheduletracker.controller;
+
+import com.example.scheduletracker.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+@AutoConfigureMockMvc     // security filters enabled
+class UserControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private UserService svc;
+
+    @Test
+    @DisplayName("GET /api/users/{username} без авторизации возвращает 401")
+    void getUserUnauthorized() throws Exception {
+        mvc.perform(get("/api/users/alice"))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## Summary
- test unauthorized access to `/api/users/{username}`

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_683f4397d7e48326915144f66857b7a9