### PR TITLE
Fix CI deployment and database config

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Deploy to VPS
         run: |
-          scp -i key.pem target/scheduletracker-0.0.1-SNAPSHOT.jar root@95.164.2.48:/proj/
+          scp -i key.pem target/scheduletracker-0.0.1-SNAPSHOT.jar Dockerfile root@95.164.2.48:/proj/
           ssh -i key.pem root@95.164.2.48 << 'EOF'
             docker stop my-java-app || true
             docker rm my-java-app  || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY scheduletracker-0.0.1-SNAPSHOT.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
      docker run --name schedule-db -p 5432:5432 -e POSTGRES_DB=schedule \
        -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres -d postgres:15
      ```
-   - В файле `src/main/resources/application.yml` хост базы указан как `db`. 
-     Если запускаете БД локально, измените его на `localhost`.
+   - В `application.yml` адрес БД задаётся через переменную окружения `DB_HOST`.
+     По умолчанию используется `localhost`.
 4. **Сборка и запуск**
    - Сборка: `./mvnw package`
    - Запуск: `./mvnw spring-boot:run`

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://db:5432/schedule
+    url: jdbc:postgresql://${DB_HOST:localhost}:5432/schedule
     username: postgres
     password: postgres
   jpa:


### PR DESCRIPTION
## Summary
- add Dockerfile to build container for Spring Boot app
- copy Dockerfile to server in deploy workflow
- make DB host configurable via `DB_HOST`
- document DB_HOST usage

## Testing
- `./mvnw test -q` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683f6e1ed8cc8326aa201cf6d8512f63