### PR TITLE
Fix deploy jar copy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,8 +40,10 @@ jobs:
     # 5. Переименовываем артефакт → app.jar (чтобы Dockerfile его нашёл)
     - name: Prepare artifact
       run: |
+        set -e
         mkdir -p build
-        cp build/libs/*.jar build/app.jar
+        JAR_FILE=$(ls build/libs/*.jar | grep -v plain | head -n 1)
+        cp "$JAR_FILE" build/app.jar
 
     - name: Generate test TLS certificate
       run: |

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ PostgreSQL, само приложение и Nginx в роли обратног�
 
 ```bash
 ./gradlew build
-cp build/libs/*.jar app.jar
+cp $(ls build/libs/*.jar | grep -v plain | head -n 1) app.jar
 docker compose up --build
 ```
 


### PR DESCRIPTION
## Summary
- avoid copying the wrong jar in deploy workflow
- update README with jar selection snippet

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew test --no-daemon` *(fails: Calculating task graph as no cached configuration is available)*

------
https://chatgpt.com/codex/tasks/task_e_68432e0484388326a395d3539031d8a9