### PR TITLE
Fix auto-merge trigger

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -10,6 +10,7 @@ jobs:
   enable-auto-merge:
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.pull_requests[0]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- skip auto merge job if deploy wasn't triggered by a PR

## Testing
- `./gradlew build`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68433076ce008326b0c76a06fed90492