### PR TITLE
Fix jar path in deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,7 +100,7 @@ jobs:
         # port:     ${{ secrets.VPS_PORT }}
         source:     backend/build/app.jar
         target:     /root/myapp
-        strip_components: 1
+        strip_components: 2
 
     # 8. Собираем Docker-образ и перезапускаем контейнер через SSH
     - name: Docker Compose up


### PR DESCRIPTION
## Summary
- ensure `app.jar` lands in root during deployment

## Testing
- `./backend/gradlew -p backend test`

------
https://chatgpt.com/codex/tasks/task_e_68436488708883268bc8a6a01626fc32