### PR TITLE
Fix nginx exporter port conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ docker compose logs app
 docker compose -f infra/docker-compose.dev.yml up -d
 ```
 
-После запуска метрики Nginx доступны на `http://localhost:9113/metrics`.
+После запуска метрики Nginx доступны на `http://localhost:9114/metrics`.
 Экспортер считывает данные со страницы `/nginx_status` внутри контейнера.
 
 

--- a/backend/src/main/resources/static/patch.diff
+++ b/backend/src/main/resources/static/patch.diff
@@ -286,7 +286,7 @@ index f80bb8b2fb0dbf5efe6f03209579ce2e24f33c02..da64c83437cd939b77c4b5c5589afb59
 +docker compose -f infra/docker-compose.dev.yml up -d
  ```
  
- После запуска метрики Nginx доступны на `http://localhost:9113/metrics`.
+После запуска метрики Nginx доступны на `http://localhost:9114/metrics`.
  Экспортер считывает данные со страницы `/nginx_status` внутри контейнера.
  
  

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -39,4 +39,4 @@ services:
     command:
       - --nginx.scrape-uri=http://nginx/nginx_status
     ports:
-      - "9113:9113"
+      - "9114:9113"


### PR DESCRIPTION
## Summary
- update nginx exporter port mapping to 9114
- update docs to reference new port

## Testing
- `./backend/gradlew -p backend test`
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684369c835888326960514f43d35304d