### PR TITLE
Implement basic auth layout

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -101,7 +101,7 @@ audit_log(id bigserial, entity, entity_id, action, old_json, new_json, actor_id,
 
 | # | Feature                      | Est | Key Components                                                  |
 | - | ---------------------------- | --- | --------------------------------------------------------------- |
-| 1 | Auth & layout                | 3 h | `<AuthGate/>`, `<Sidebar/>`, React Router v6                    |
+| 1 | Auth & layout                | 3 h | `<AuthGate/>`, `<Sidebar/>`, React Router v6 ✅ DONE |
 | 2 | Teacher calendar             | 4 h | `<TeacherCalendar/>`, FullCalendar, availability template modal |
 | 3 | Manager timeline             | 5 h | `<ManagerCalendar/>` with teacher selector, Lesson modal        |
 | 4 | Student search & CRUD        | 2 h | `<StudentCombobox/>`, `<StudentDialog/>`                        |

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,12 +11,14 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^6.22.3"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
+    "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^4.4.1",
     "eslint": "^9.25.0",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,35 +1,36 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { AuthProvider } from './auth';
+import { AuthGate } from './components/AuthGate';
+import { LoginPage } from './pages/LoginPage';
+import { DashboardPage } from './pages/DashboardPage';
+import { SettingsPage } from './pages/SettingsPage';
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+    <BrowserRouter>
+      <AuthProvider>
+        <Routes>
+          <Route path="/login" element={<LoginPage />} />
+          <Route
+            path="/settings"
+            element={
+              <AuthGate>
+                <SettingsPage />
+              </AuthGate>
+            }
+          />
+          <Route
+            path="/"
+            element={
+              <AuthGate>
+                <DashboardPage />
+              </AuthGate>
+            }
+          />
+        </Routes>
+      </AuthProvider>
+    </BrowserRouter>
+  );
 }
 
-export default App
+export default App;

--- a/frontend/src/auth.tsx
+++ b/frontend/src/auth.tsx
@@ -1,0 +1,42 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export interface AuthContextValue {
+  token: string | null;
+  login: (t: string) => void;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [token, setToken] = useState<string | null>(() => localStorage.getItem('token'));
+  const navigate = useNavigate();
+
+  const login = (t: string) => {
+    localStorage.setItem('token', t);
+    setToken(t);
+    navigate('/');
+  };
+
+  const logout = () => {
+    localStorage.removeItem('token');
+    setToken(null);
+    navigate('/login');
+  };
+
+  useEffect(() => {
+    if (!token) {
+      navigate('/login');
+    }
+  }, [token, navigate]);
+
+  const value: AuthContextValue = { token, login, logout };
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('AuthProvider missing');
+  return ctx;
+};

--- a/frontend/src/components/AuthGate.tsx
+++ b/frontend/src/components/AuthGate.tsx
@@ -1,0 +1,9 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../auth';
+import type { ReactElement } from 'react';
+
+export const AuthGate = ({ children }: { children: ReactElement }) => {
+  const { token } = useAuth();
+  if (!token) return <Navigate to="/login" replace />;
+  return children;
+};

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,18 @@
+import { NavLink } from 'react-router-dom';
+import { useAuth } from '../auth';
+
+const linkClass = ({ isActive }: { isActive: boolean }) =>
+  isActive ? 'font-bold text-blue-500' : 'text-gray-700';
+
+export const Sidebar = () => {
+  const { logout } = useAuth();
+  return (
+    <aside className="w-48 p-4 border-r h-screen flex flex-col">
+      <nav className="flex-1 space-y-2">
+        <NavLink className={linkClass} to="/">Dashboard</NavLink>
+        <NavLink className={linkClass} to="/settings">Settings</NavLink>
+      </nav>
+      <button onClick={logout} className="text-red-600 mt-auto">Logout</button>
+    </aside>
+  );
+};

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,0 +1,10 @@
+import { Sidebar } from '../components/Sidebar';
+
+export const DashboardPage = () => {
+  return (
+    <div className="flex">
+      <Sidebar />
+      <div className="p-4 flex-1">Welcome to dashboard!</div>
+    </div>
+  );
+};

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,28 @@
+import { useState, type FormEvent } from 'react';
+import { useAuth } from '../auth';
+
+export const LoginPage = () => {
+  const { login } = useAuth();
+  const [value, setValue] = useState('');
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    login(value || 'demo-token');
+  };
+
+  return (
+    <div className="flex items-center justify-center h-screen">
+      <form onSubmit={handleSubmit} className="space-y-2 p-4 border rounded">
+        <input
+          className="border p-1"
+          placeholder="Token"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+        />
+        <button type="submit" className="bg-blue-500 text-white px-2 py-1">
+          Login
+        </button>
+      </form>
+    </div>
+  );
+};

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,0 +1,8 @@
+import { Sidebar } from '../components/Sidebar';
+
+export const SettingsPage = () => (
+  <div className="flex">
+    <Sidebar />
+    <div className="p-4 flex-1">Settings page</div>
+  </div>
+);


### PR DESCRIPTION
## Summary
- add simple frontend auth gate and sidebar
- wire up routes in `App.tsx`
- document progress in TASKS

## Testing
- `npm run lint`
- `npm run build`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68436b67a6e88326b456a69b96d7f6a7