### PR TITLE
Fix missing compose file in deploy logs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,4 +123,4 @@ jobs:
           docker compose -f infra/docker-compose.dev.yml build --no-cache
           docker compose -f infra/docker-compose.dev.yml up -d
           docker compose -f infra/docker-compose.dev.yml ps
-          docker compose logs app --tail=20
+          docker compose -f infra/docker-compose.dev.yml logs app --tail=20


### PR DESCRIPTION
## Summary
- fix docker logs step in `deploy.yml` workflow

## Testing
- `./gradlew test`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68436e0109d0832693b425fc54e4b6ec