### PR TITLE
Add manager calendar page

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -103,7 +103,7 @@ audit_log(id bigserial, entity, entity_id, action, old_json, new_json, actor_id,
 | - | ---------------------------- | --- | --------------------------------------------------------------- |
 | 1 | Auth & layout                | 3 h | `<AuthGate/>`, `<Sidebar/>`, React Router v6 ✅ DONE |
 | 2 | Teacher calendar             | 4 h | `<TeacherCalendar/>`, FullCalendar, availability template modal ✅ DONE |
-| 3 | Manager timeline             | 5 h | `<ManagerCalendar/>` with teacher selector, Lesson modal        |
+| 3 | Manager timeline             | 5 h | `<ManagerCalendar/>` with teacher selector, Lesson modal ✅ DONE |
 | 4 | Student search & CRUD        | 2 h | `<StudentCombobox/>`, `<StudentDialog/>`                        |
 | 5 | Settings (buffer, templates) | 3 h | `<SettingsPage/>`, TipTap editor                                |
 | 6 | Analytics dashboard          | 3 h | React Query fetch → `<LineChart/>` (recharts)                   |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { LoginPage } from './pages/LoginPage';
 import { DashboardPage } from './pages/DashboardPage';
 import { SettingsPage } from './pages/SettingsPage';
 import { TeacherCalendarPage } from './pages/TeacherCalendarPage';
+import { ManagerCalendarPage } from './pages/ManagerCalendarPage';
 
 function App() {
   return (
@@ -25,6 +26,14 @@ function App() {
             element={
               <AuthGate>
                 <TeacherCalendarPage />
+              </AuthGate>
+            }
+          />
+          <Route
+            path="/manager"
+            element={
+              <AuthGate>
+                <ManagerCalendarPage />
               </AuthGate>
             }
           />

--- a/frontend/src/components/ManagerCalendar.tsx
+++ b/frontend/src/components/ManagerCalendar.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from 'react';
+import FullCalendar from '@fullcalendar/react';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import timeGridPlugin from '@fullcalendar/timegrid';
+import { type EventInput } from '@fullcalendar/core';
+
+interface Teacher {
+  id: number;
+  name: string;
+}
+
+interface Lesson {
+  id: number;
+  dateTime: string;
+  duration: number;
+  group?: { name: string };
+}
+
+export const ManagerCalendar = () => {
+  const [teachers, setTeachers] = useState<Teacher[]>([]);
+  const [teacherId, setTeacherId] = useState<number | null>(null);
+  const [events, setEvents] = useState<EventInput[]>([]);
+  const [modalLesson, setModalLesson] = useState<Lesson | null>(null);
+
+  useEffect(() => {
+    fetch('/api/teachers')
+      .then((r) => r.json())
+      .then((data: Teacher[]) => {
+        setTeachers(data);
+        if (data.length > 0) setTeacherId(data[0].id);
+      });
+  }, []);
+
+  useEffect(() => {
+    if (!teacherId) return;
+    fetch(`/api/lessons?teacherId=${teacherId}`)
+      .then((r) => r.json())
+      .then((data: Lesson[]) =>
+        setEvents(
+          data.map((l) => ({
+            id: String(l.id),
+            title: l.group?.name ?? 'Lesson',
+            start: l.dateTime,
+            end: new Date(new Date(l.dateTime).getTime() + l.duration * 60000).toISOString(),
+            extendedProps: l,
+          }))
+        )
+      );
+  }, [teacherId]);
+
+  return (
+    <div>
+      <div className="mb-2">
+        <label htmlFor="teacher" className="mr-2">Teacher:</label>
+        <select
+          id="teacher"
+          value={teacherId ?? ''}
+          onChange={(e) => setTeacherId(Number(e.target.value))}
+          className="border p-1"
+        >
+          {teachers.map((t) => (
+            <option key={t.id} value={t.id}>{t.name}</option>
+          ))}
+        </select>
+      </div>
+      <FullCalendar
+        plugins={[dayGridPlugin, timeGridPlugin]}
+        initialView="timeGridWeek"
+        events={events}
+        eventClick={(info) => {
+          setModalLesson(info.event.extendedProps as Lesson);
+        }}
+      />
+      {modalLesson && (
+        <dialog open className="p-4 rounded bg-white shadow-lg">
+          <h2 className="text-lg font-bold mb-2">Lesson #{modalLesson.id}</h2>
+          <p>Group: {modalLesson.group?.name ?? 'n/a'}</p>
+          <p>Start: {new Date(modalLesson.dateTime).toLocaleString()}</p>
+          <p>Duration: {modalLesson.duration} min</p>
+          <button
+            className="mt-2 px-2 py-1 border"
+            onClick={() => setModalLesson(null)}
+          >
+            Close
+          </button>
+        </dialog>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -11,6 +11,7 @@ export const Sidebar = () => {
       <nav className="flex-1 space-y-2">
         <NavLink className={linkClass} to="/">Dashboard</NavLink>
         <NavLink className={linkClass} to="/calendar">Calendar</NavLink>
+        <NavLink className={linkClass} to="/manager">Timeline</NavLink>
         <NavLink className={linkClass} to="/settings">Settings</NavLink>
       </nav>
       <button onClick={logout} className="text-red-600 mt-auto">Logout</button>

--- a/frontend/src/components/TeacherCalendar.tsx
+++ b/frontend/src/components/TeacherCalendar.tsx
@@ -20,7 +20,7 @@ export const TeacherCalendar = () => {
       .then((data: Lesson[]) => {
         setEvents(
           data.map((l) => ({
-            id: l.id,
+            id: String(l.id),
             title: l.group?.name ?? 'Lesson',
             start: l.dateTime,
             end: new Date(new Date(l.dateTime).getTime() + l.duration * 60000).toISOString(),

--- a/frontend/src/pages/ManagerCalendarPage.tsx
+++ b/frontend/src/pages/ManagerCalendarPage.tsx
@@ -1,0 +1,11 @@
+import { Sidebar } from '../components/Sidebar';
+import { ManagerCalendar } from '../components/ManagerCalendar';
+
+export const ManagerCalendarPage = () => (
+  <div className="flex">
+    <Sidebar />
+    <div className="flex-1 p-4">
+      <ManagerCalendar />
+    </div>
+  </div>
+);


### PR DESCRIPTION
## Summary
- implement `<ManagerCalendar>` with teacher selector and lesson modal
- add page `<ManagerCalendarPage>` and route `/manager`
- link to the manager view in `<Sidebar>`
- adjust `<TeacherCalendar>` ids for TypeScript strictness
- mark corresponding task done in `TASKS.md`

## Testing
- `npm run build`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6843720c0b3c8326952f53e411fb1a10