### PR TITLE
Fix frontend build issues

### DIFF
--- a/frontend/src/components/StudentDialog.tsx
+++ b/frontend/src/components/StudentDialog.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Student } from './StudentCombobox';
+import type { Student } from './StudentCombobox';
 
 interface Props {
   student?: Student;

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -8,11 +8,13 @@ interface Point {
 }
 
 export const DashboardPage = () => {
-  const { data } = useQuery<Point[]>(['analytics'], () =>
-    fetch('/api/analytics')
-      .then((r) => r.json())
-      .then((d) => d as Point[])
-  );
+  const { data } = useQuery<Point[]>({
+    queryKey: ['analytics'],
+    queryFn: () =>
+      fetch('/api/analytics')
+        .then((r) => r.json())
+        .then((d) => d as Point[]),
+  });
 
   return (
     <div className="flex">

--- a/frontend/src/pages/StudentsPage.tsx
+++ b/frontend/src/pages/StudentsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Sidebar } from '../components/Sidebar';
-import { Student } from '../components/StudentCombobox';
+import type { Student } from '../components/StudentCombobox';
 import { StudentDialog } from '../components/StudentDialog';
 
 export const StudentsPage = () => {


### PR DESCRIPTION
## Summary
- fix type-only imports for TypeScript with `verbatimModuleSyntax`
- correct `useQuery` invocation in dashboard page

## Testing
- `npm run lint`
- `npm run build` in frontend
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6843fa801a6083268c95fb2e3e3c7260