### PR TITLE
Fix nginx resolver for Docker

### DIFF
--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -45,7 +45,11 @@ http {
         ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384';
         ssl_stapling on;
         ssl_stapling_verify on;
-        resolver 8.8.8.8 1.1.1.1 valid=300s;
+        # Docker containers resolve service names via an embedded DNS server
+        # available at 127.0.0.11. Using public resolvers breaks name
+        # resolution for compose services like `app`. Point explicitly to the
+        # internal resolver to avoid startup errors.
+        resolver 127.0.0.11 ipv6=off valid=30s;
         resolver_timeout 5s;
 
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;

--- a/infra/nginx/nginx.conf.template
+++ b/infra/nginx/nginx.conf.template
@@ -45,7 +45,11 @@ http {
         ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384';
         ssl_stapling on;
         ssl_stapling_verify on;
-        resolver 8.8.8.8 1.1.1.1 valid=300s;
+        # Docker containers resolve service names via an embedded DNS server
+        # available at 127.0.0.11. Using public resolvers breaks name
+        # resolution for compose services like `app`. Point explicitly to the
+        # internal resolver to avoid startup errors.
+        resolver 127.0.0.11 ipv6=off valid=30s;
         resolver_timeout 5s;
 
         add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;


### PR DESCRIPTION
## Summary
- use Docker's internal resolver in nginx configs to prevent host not found errors

## Testing
- `./backend/gradlew -p backend test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68440370068c8326bc27809f91e2c408