### PR TITLE
fix: include tls certs mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,12 @@ docker run --rm -it --network app-network \
 
 Для удобства можно воспользоваться `infra/docker-compose.dev.yml`, который
 поднимет PostgreSQL, само приложение и Nginx в роли обратного прокси. Перед
-запуском убедитесь, что в каталоге `backend/` есть `app.jar`:
+запуском убедитесь, что в каталоге `backend/` есть `app.jar`. Также
+создайте самоподписанный сертификат в `infra/nginx/certs`:
+
+```bash
+openssl req -x509 -newkey rsa:2048 -nodes -keyout infra/nginx/certs/server.key -out infra/nginx/certs/server.crt -days 365 -subj "/CN=localhost"
+```
 
 ```bash
 ./gradlew build

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -29,6 +29,7 @@ services:
     restart: unless-stopped
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/certs:/etc/nginx/certs:ro
     ports:
       - "80:80"
 


### PR DESCRIPTION
## Summary
- mount nginx TLS certs in dev compose
- document how to generate a self-signed certificate

## Testing
- `./gradlew --version`
- `npm run build` *(fails: tailwindcss not found)*

------
https://chatgpt.com/codex/tasks/task_e_684406022eb0832686f86f70f32b684f