### PR TITLE
fix: container startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ openssl req -x509 -newkey rsa:2048 -nodes -keyout infra/nginx/certs/server.key -
 cp $(ls build/libs/*.jar | grep -v plain | head -n 1) app.jar
 cd ..
 docker compose -f infra/docker-compose.dev.yml up --build
+
+При запуске `nginx` отдельно используйте переменные окружения `APP_HOST` и
+`APP_PORT` для указания адреса backend-сервиса. Контейнер автоматически
+подставит их в `nginx.conf.template`.
 ```
 
 ### Проверка сервиса

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -27,8 +27,11 @@ services:
     depends_on:
       - app
     restart: unless-stopped
+    environment:
+      APP_HOST: app
+      APP_PORT: 8080
     volumes:
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/nginx.conf.template:/etc/nginx/templates/nginx.conf.template:ro
       - ./nginx/certs:/etc/nginx/certs:ro
     ports:
       - "80:80"


### PR DESCRIPTION
## Summary
- mount nginx template into compose and set default vars
- note APP_HOST/APP_PORT usage when launching nginx standalone

## Testing
- `./gradlew test --tests com.example.scheduletracker.controller.HelloControllerTest --console=plain -q` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68440a8cb2788326bf491b187c6e68ae