### PR TITLE
Fix tsrange for timestamptz columns

### DIFF
--- a/backend/src/main/resources/db/migration/V4__definitive.sql
+++ b/backend/src/main/resources/db/migration/V4__definitive.sql
@@ -113,4 +113,5 @@ CREATE TABLE audit_log (
     ts TIMESTAMPTZ DEFAULT now()
 );
 
-CREATE INDEX time_slot_overlap ON time_slot USING GIST (tsrange(start_ts, end_ts));
+-- Use `tstzrange` because `start_ts`/`end_ts` are TIMESTAMPTZ values
+CREATE INDEX time_slot_overlap ON time_slot USING GIST (tstzrange(start_ts, end_ts));


### PR DESCRIPTION
## Summary
- adjust V4 migration to use `tstzrange` for TIMESTAMPTZ columns

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684412a869e083269cf5ad5e27b36242