### PR TITLE
Fix telegram service initialization

### DIFF
--- a/backend/src/main/java/com/example/scheduletracker/service/impl/TelegramNotificationService.java
+++ b/backend/src/main/java/com/example/scheduletracker/service/impl/TelegramNotificationService.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Primary;
 import org.springframework.http.HttpEntity;
@@ -23,6 +24,7 @@ public class TelegramNotificationService implements NotificationService {
     private final RestTemplate restTemplate;
     private final String apiUrl;
 
+    @Autowired
     public TelegramNotificationService(@Value("${telegram.bot-token}") String token) {
         this(new RestTemplate(), token);
     }


### PR DESCRIPTION
## Summary
- allow Spring to autowire TelegramNotificationService constructor

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684416fc4b888326af2bbcf62b52b784