### PR TITLE
fix: align user entity with updated schema

### DIFF
--- a/backend/src/main/java/com/example/scheduletracker/dto/UserDto.java
+++ b/backend/src/main/java/com/example/scheduletracker/dto/UserDto.java
@@ -1,4 +1,6 @@
 package com.example.scheduletracker.dto;
 
 /** Lightweight representation of a user */
-public record UserDto(Long id, String username, String role) {}
+import java.util.UUID;
+
+public record UserDto(UUID id, String username, String role) {}

--- a/backend/src/main/java/com/example/scheduletracker/entity/User.java
+++ b/backend/src/main/java/com/example/scheduletracker/entity/User.java
@@ -1,19 +1,23 @@
 package com.example.scheduletracker.entity;
 
 import jakarta.persistence.*;
+import java.util.UUID;
+import org.hibernate.annotations.GenericGenerator;
 
 /** User of the system. */
 @Entity
 @Table(name = "users")
 public class User {
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+  @GeneratedValue(generator = "UUID")
+  @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
+  @Column(columnDefinition = "uuid", updatable = false, nullable = false)
+  private UUID id;
 
-  @Column(unique = true, nullable = false)
+  @Column(name = "email", unique = true, nullable = false)
   private String username;
 
-  @Column(nullable = false)
+  @Column(name = "pwd", nullable = false)
   private String password;
 
   @Enumerated(EnumType.STRING)
@@ -25,7 +29,7 @@ public class User {
 
   public User() {}
 
-  public User(Long id, String username, String password, Role role, String twoFaSecret) {
+  public User(UUID id, String username, String password, Role role, String twoFaSecret) {
     this.id = id;
     this.username = username;
     this.password = password;
@@ -33,11 +37,11 @@ public class User {
     this.twoFaSecret = twoFaSecret;
   }
 
-  public Long getId() {
+  public UUID getId() {
     return id;
   }
 
-  public void setId(Long id) {
+  public void setId(UUID id) {
     this.id = id;
   }
 
@@ -78,13 +82,13 @@ public class User {
   }
 
   public static class Builder {
-    private Long id;
+    private UUID id;
     private String username;
     private String password;
     private Role role;
     private String twoFaSecret;
 
-    public Builder id(Long id) {
+    public Builder id(UUID id) {
       this.id = id;
       return this;
     }

--- a/backend/src/main/java/com/example/scheduletracker/repository/UserRepository.java
+++ b/backend/src/main/java/com/example/scheduletracker/repository/UserRepository.java
@@ -5,6 +5,8 @@ import com.example.scheduletracker.entity.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
   Optional<User> findByUsername(String username);
 }

--- a/backend/src/test/java/com/example/scheduletracker/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/example/scheduletracker/controller/AuthControllerTest.java
@@ -48,7 +48,8 @@ class AuthControllerTest {
   void registerCreatesUser() throws Exception {
     when(userService.findByUsername("new")).thenReturn(java.util.Optional.empty());
     when(totpService.generateSecret()).thenReturn("secret");
-    when(userService.save(any())).thenReturn(new User(1L, "new", "p", User.Role.STUDENT, "secret"));
+    when(userService.save(any()))
+        .thenReturn(new User(java.util.UUID.randomUUID(), "new", "p", User.Role.STUDENT, "secret"));
 
     mvc.perform(
             post("/api/auth/register")


### PR DESCRIPTION
## Summary
- update user table mappings to new UUID-based schema
- adjust repository generics and tests

## Testing
- `./gradlew test`
- `./gradlew spotlessCheck` *(fails: task not found)*
- `./gradlew sonar:sonar` *(fails: task not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844193cb8188326a301473721c1aeba