### PR TITLE
Fix Flyway migration target

### DIFF
--- a/backend/src/main/resources/application-h2.yml
+++ b/backend/src/main/resources/application-h2.yml
@@ -11,3 +11,4 @@ spring:
   flyway:
     locations: classpath:db/migration
     baseline-on-migrate: true
+    target: 3

--- a/backend/src/main/resources/application-postgres.yml
+++ b/backend/src/main/resources/application-postgres.yml
@@ -10,3 +10,4 @@ spring:
   flyway:
     locations: classpath:db/migration
     baseline-on-migrate: true
+    target: 3


### PR DESCRIPTION
## Summary
- use only legacy migrations by pinning Flyway target version to `3`

## Testing
- `./gradlew test --no-daemon`
- `npm run lint --silent`

------
https://chatgpt.com/codex/tasks/task_e_68441f72db108326b6adeba31b1a6c49