### PR TITLE
fix: pin flyway to legacy schema

### DIFF
--- a/backend/src/main/resources/application-h2.yml
+++ b/backend/src/main/resources/application-h2.yml
@@ -11,4 +11,4 @@ spring:
   flyway:
     locations: classpath:db/migration
     baseline-on-migrate: true
-    target: 7
+    target: 3

--- a/backend/src/main/resources/application-postgres.yml
+++ b/backend/src/main/resources/application-postgres.yml
@@ -10,4 +10,4 @@ spring:
   flyway:
     locations: classpath:db/migration
     baseline-on-migrate: true
-    target: 7
+    target: 3


### PR DESCRIPTION
## Summary
- use the old DB schema while code isn't migrated

## Testing
- `./backend/gradlew test` *(fails: Directory '/workspace/trash' does not contain a Gradle build)*

------
https://chatgpt.com/codex/tasks/task_e_68444508ab3c8326a9781b276dab7631