### PR TITLE
Fix SPA route handling

### DIFF
--- a/backend/src/main/java/com/example/scheduletracker/controller/SpaController.java
+++ b/backend/src/main/java/com/example/scheduletracker/controller/SpaController.java
@@ -1,0 +1,18 @@
+package com.example.scheduletracker.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class SpaController {
+
+    @GetMapping(value = "/{path:^(?!api|swagger-ui$).*$}")
+    public String redirectRoot() {
+        return "forward:/index.html";
+    }
+
+    @GetMapping(value = "/**/{path:^(?!api|swagger-ui$)[^\\.]*}")
+    public String redirect() {
+        return "forward:/index.html";
+    }
+}

--- a/backend/src/test/java/com/example/scheduletracker/controller/SpaControllerTest.java
+++ b/backend/src/test/java/com/example/scheduletracker/controller/SpaControllerTest.java
@@ -1,0 +1,30 @@
+package com.example.scheduletracker.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.forwardedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(SpaController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class SpaControllerTest {
+
+  @Autowired private MockMvc mvc;
+
+  @MockBean private com.example.scheduletracker.config.jwt.JwtUtils utils;
+
+  @Test
+  @DisplayName("SPA routes forward to index.html")
+  void spaRoutesForwardToIndex() throws Exception {
+    mvc.perform(get("/calendar"))
+        .andExpect(status().isOk())
+        .andExpect(forwardedUrl("/index.html"));
+  }
+}


### PR DESCRIPTION
## Summary
- forward unknown routes to `index.html` so SPA works behind NGINX
- add test to verify forwarding logic

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6844612697ec8326bffa7115a4ad7e28