### PR TITLE
Fix auth DTO validation

### DIFF
--- a/backend/src/main/java/com/example/scheduletracker/controller/AuthController.java
+++ b/backend/src/main/java/com/example/scheduletracker/controller/AuthController.java
@@ -8,6 +8,7 @@ import com.example.scheduletracker.entity.User;
 import com.example.scheduletracker.service.UserService;
 import com.example.scheduletracker.service.security.TotpService;
 import com.example.scheduletracker.dto.SignupResponse;
+import jakarta.validation.Valid;
 import java.util.Optional;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -36,7 +37,7 @@ public class AuthController {
   }
 
   @PostMapping("/login")
-  public ResponseEntity<JwtResponse> login(@RequestBody LoginRequest req) {
+  public ResponseEntity<JwtResponse> login(@Valid @RequestBody LoginRequest req) {
     Authentication auth =
         authManager.authenticate(
             new UsernamePasswordAuthenticationToken(req.username(), req.password()));
@@ -50,7 +51,7 @@ public class AuthController {
   }
 
   @PostMapping("/register")
-  public ResponseEntity<SignupResponse> register(@RequestBody SignupRequest req) {
+  public ResponseEntity<SignupResponse> register(@Valid @RequestBody SignupRequest req) {
     String username = req.username();
     Optional<User> existing = userService.findByUsername(username);
     if (existing.isPresent()) {

--- a/backend/src/main/java/com/example/scheduletracker/dto/LoginRequest.java
+++ b/backend/src/main/java/com/example/scheduletracker/dto/LoginRequest.java
@@ -1,4 +1,10 @@
 package com.example.scheduletracker.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 /** Credentials provided by a user when logging in. */
-public record LoginRequest(String username, String password, String code) {}
+public record LoginRequest(
+    @NotBlank String username,
+    @NotBlank String password,
+    @Size(min = 6, max = 6) String code) {}

--- a/backend/src/main/java/com/example/scheduletracker/dto/SignupRequest.java
+++ b/backend/src/main/java/com/example/scheduletracker/dto/SignupRequest.java
@@ -1,4 +1,10 @@
 package com.example.scheduletracker.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 /** Payload for user registration. */
-public record SignupRequest(String username, String password, String role) {}
+public record SignupRequest(
+    @NotBlank String username,
+    @NotBlank String password,
+    @Size(min = 1) String role) {}

--- a/backend/src/test/java/com/example/scheduletracker/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/example/scheduletracker/controller/AuthControllerTest.java
@@ -57,4 +57,22 @@ class AuthControllerTest {
                 .content("{\"username\":\"new\",\"password\":\"p\"}"))
         .andExpect(status().isCreated());
   }
+
+  @Test
+  void loginWithShortCodeFails() throws Exception {
+    mvc.perform(
+            post("/api/auth/login")
+                .contentType("application/json")
+                .content("{\"username\":\"u\",\"password\":\"p\",\"code\":\"123\"}"))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void registerWithoutUsernameFails() throws Exception {
+    mvc.perform(
+            post("/api/auth/register")
+                .contentType("application/json")
+                .content("{\"password\":\"p\"}"))
+        .andExpect(status().isBadRequest());
+  }
 }


### PR DESCRIPTION
## Summary
- enforce validation on auth DTOs
- validate request bodies in `AuthController`
- test invalid login and registration payloads

## Testing
- `cd backend && ./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684471e595dc8326a469ee9afe187489