### PR TITLE
Add Spotless and Jacoco plugins

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
     id("org.springframework.boot") version "3.5.0"
     id("io.spring.dependency-management") version "1.1.4"
     java
+    id("com.diffplug.spotless") version "6.25.0"
+    jacoco
 }
 
 repositories {
@@ -57,4 +59,23 @@ tasks.withType<JavaCompile>() {
 
 tasks.withType<Javadoc>() {
     options.encoding = "UTF-8"
+}
+
+spotless {
+    java {
+        googleJavaFormat()
+        target("src/*/java/**/*.java")
+    }
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+}
+
+tasks.named("check") {
+    dependsOn(tasks.jacocoTestReport)
 }


### PR DESCRIPTION
## Summary
- apply Spotless and Jacoco plugins
- add Google Java format
- generate Jacoco report and hook it into `check`

## Testing
- `./gradlew spotlessCheck jacocoTestReport --stacktrace --no-daemon` *(fails: Spotless violations)*

------
https://chatgpt.com/codex/tasks/task_e_684473fc1bf083269e72c8725fb247bd