### PR TITLE
Fix mismatched table names

### DIFF
--- a/backend/src/main/java/com/example/scheduletracker/entity/AvailabilityTemplate.java
+++ b/backend/src/main/java/com/example/scheduletracker/entity/AvailabilityTemplate.java
@@ -7,7 +7,7 @@ import java.time.LocalTime;
 
 /** Weekly availability template for teacher */
 @Entity
-@Table(name = "availability_templates")
+@Table(name = "availability_template")
 public class AvailabilityTemplate {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/example/scheduletracker/entity/Lesson.java
+++ b/backend/src/main/java/com/example/scheduletracker/entity/Lesson.java
@@ -5,7 +5,7 @@ import java.time.OffsetDateTime;
 
 /** Lesson entity. */
 @Entity
-@Table(name = "lessons")
+@Table(name = "lesson")
 public class Lesson {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/example/scheduletracker/entity/NotificationTemplate.java
+++ b/backend/src/main/java/com/example/scheduletracker/entity/NotificationTemplate.java
@@ -3,7 +3,7 @@ package com.example.scheduletracker.entity;
 import jakarta.persistence.*;
 
 @Entity
-@Table(name = "notification_templates")
+@Table(name = "notification_template")
 public class NotificationTemplate {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/example/scheduletracker/entity/TimeSlot.java
+++ b/backend/src/main/java/com/example/scheduletracker/entity/TimeSlot.java
@@ -5,7 +5,7 @@ import java.time.OffsetDateTime;
 
 /** Time slot for teacher availability. */
 @Entity
-@Table(name = "time_slots")
+@Table(name = "time_slot")
 public class TimeSlot {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## Summary
- sync entity `@Table` annotations with migration names

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68449c193a548326b01a0d8fb4b8eb40