### PR TITLE
refactor: align TimeSlot column names

### DIFF
--- a/backend/src/main/java/com/example/scheduletracker/entity/TimeSlot.java
+++ b/backend/src/main/java/com/example/scheduletracker/entity/TimeSlot.java
@@ -19,19 +19,19 @@ public class TimeSlot {
   @JoinColumn(name = "teacher_id")
   private Teacher teacher;
 
-  @Column(nullable = false)
-  private OffsetDateTime start;
+  @Column(name = "start_ts", nullable = false)
+  private OffsetDateTime startTs;
 
-  @Column(name = "end_time", nullable = false)
-  private OffsetDateTime endTime;
+  @Column(name = "end_ts", nullable = false)
+  private OffsetDateTime endTs;
 
   public TimeSlot() {}
 
-  public TimeSlot(UUID id, Teacher teacher, OffsetDateTime start, OffsetDateTime endTime) {
+  public TimeSlot(UUID id, Teacher teacher, OffsetDateTime startTs, OffsetDateTime endTs) {
     this.id = id;
     this.teacher = teacher;
-    this.start = start;
-    this.endTime = endTime;
+    this.startTs = startTs;
+    this.endTs = endTs;
   }
 
   public UUID getId() {
@@ -50,20 +50,20 @@ public class TimeSlot {
     this.teacher = teacher;
   }
 
-  public OffsetDateTime getStart() {
-    return start;
+  public OffsetDateTime getStartTs() {
+    return startTs;
   }
 
-  public void setStart(OffsetDateTime start) {
-    this.start = start;
+  public void setStartTs(OffsetDateTime startTs) {
+    this.startTs = startTs;
   }
 
-  public OffsetDateTime getEndTime() {
-    return endTime;
+  public OffsetDateTime getEndTs() {
+    return endTs;
   }
 
-  public void setEndTime(OffsetDateTime endTime) {
-    this.endTime = endTime;
+  public void setEndTs(OffsetDateTime endTs) {
+    this.endTs = endTs;
   }
 
   public static Builder builder() {
@@ -73,8 +73,8 @@ public class TimeSlot {
   public static class Builder {
     private UUID id;
     private Teacher teacher;
-    private OffsetDateTime start;
-    private OffsetDateTime endTime;
+    private OffsetDateTime startTs;
+    private OffsetDateTime endTs;
 
     public Builder id(UUID id) {
       this.id = id;
@@ -86,18 +86,18 @@ public class TimeSlot {
       return this;
     }
 
-    public Builder start(OffsetDateTime start) {
-      this.start = start;
+    public Builder startTs(OffsetDateTime startTs) {
+      this.startTs = startTs;
       return this;
     }
 
-    public Builder endTime(OffsetDateTime endTime) {
-      this.endTime = endTime;
+    public Builder endTs(OffsetDateTime endTs) {
+      this.endTs = endTs;
       return this;
     }
 
     public TimeSlot build() {
-      return new TimeSlot(id, teacher, start, endTime);
+      return new TimeSlot(id, teacher, startTs, endTs);
     }
   }
 }

--- a/backend/src/main/java/com/example/scheduletracker/repository/TimeSlotRepository.java
+++ b/backend/src/main/java/com/example/scheduletracker/repository/TimeSlotRepository.java
@@ -17,7 +17,7 @@ public interface TimeSlotRepository extends JpaRepository<TimeSlot, UUID> {
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query(
-      "select t from TimeSlot t where t.teacher.id = :teacherId and t.start <= :start and t.endTime >= :end")
+      "select t from TimeSlot t where t.teacher.id = :teacherId and t.startTs <= :start and t.endTs >= :end")
   Optional<TimeSlot> findSlotForPeriodLocked(
       @Param("teacherId") UUID teacherId,
       @Param("start") OffsetDateTime start,

--- a/backend/src/main/java/com/example/scheduletracker/service/impl/AvailabilityServiceImpl.java
+++ b/backend/src/main/java/com/example/scheduletracker/service/impl/AvailabilityServiceImpl.java
@@ -76,8 +76,8 @@ public class AvailabilityServiceImpl implements AvailabilityService {
           TimeSlot slot =
               TimeSlot.builder()
                   .teacher(teacher)
-                  .start(startDateTime.atOffset(java.time.ZoneOffset.UTC))
-                  .endTime(endDateTime.atOffset(java.time.ZoneOffset.UTC))
+                  .startTs(startDateTime.atOffset(java.time.ZoneOffset.UTC))
+                  .endTs(endDateTime.atOffset(java.time.ZoneOffset.UTC))
                   .build();
           created.add(slotRepository.save(slot));
         }
@@ -94,7 +94,7 @@ public class AvailabilityServiceImpl implements AvailabilityService {
         teacherRepository.findById(teacherId).orElseThrow(() -> new IllegalArgumentException("teacher"));
     List<TimeSlot> slots = slotRepository.findByTeacher(teacher);
     for (TimeSlot s : slots) {
-      if (!s.getStart().toLocalDate().isBefore(from)) {
+      if (!s.getStartTs().toLocalDate().isBefore(from)) {
         slotRepository.delete(s);
       }
     }

--- a/backend/src/main/java/com/example/scheduletracker/service/impl/LessonServiceImpl.java
+++ b/backend/src/main/java/com/example/scheduletracker/service/impl/LessonServiceImpl.java
@@ -33,7 +33,7 @@ public class LessonServiceImpl implements LessonService {
     // check that lesson fits teacher time slots
     List<TimeSlot> slots = slotRepo.findByTeacher(lesson.getTeacher());
     boolean withinSlot =
-        slots.stream().anyMatch(s -> !s.getStart().isAfter(start) && !s.getEndTime().isBefore(end));
+        slots.stream().anyMatch(s -> !s.getStartTs().isAfter(start) && !s.getEndTs().isBefore(end));
     if (!withinSlot) {
       throw new IllegalArgumentException("Lesson time outside teacher slots");
     }


### PR DESCRIPTION
## Summary
- rename `start`/`endTime` fields to `startTs`/`endTs`
- update repository queries and service logic
- keep migrations intact

## Testing
- `./backend/gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_6844a765372083268ad79eba76f0904e