### PR TITLE
Add tables for Group and TeacherStudent

### DIFF
--- a/backend/src/main/resources/db/migration/V2__fix_tables.sql
+++ b/backend/src/main/resources/db/migration/V2__fix_tables.sql
@@ -1,0 +1,11 @@
+CREATE TABLE groups (
+    id UUID PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    description TEXT
+);
+
+CREATE TABLE teacher_students (
+    teacher_id UUID NOT NULL REFERENCES teachers(id),
+    student_id UUID NOT NULL REFERENCES students(id),
+    PRIMARY KEY (teacher_id, student_id)
+);


### PR DESCRIPTION
## Summary
- add missing DB migration for `groups` and `teacher_students` tables

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6844aa3b026c8326a618f0fca77279c4