### PR TITLE
Switch to string IDs in React

### DIFF
--- a/frontend/src/components/ManagerCalendar.tsx
+++ b/frontend/src/components/ManagerCalendar.tsx
@@ -5,12 +5,12 @@ import timeGridPlugin from '@fullcalendar/timegrid';
 import { type EventInput } from '@fullcalendar/core';
 
 interface Teacher {
-  id: number;
+  id: string;
   name: string;
 }
 
 interface Lesson {
-  id: number;
+  id: string;
   dateTime: string;
   duration: number;
   group?: { name: string };
@@ -18,7 +18,7 @@ interface Lesson {
 
 export const ManagerCalendar = () => {
   const [teachers, setTeachers] = useState<Teacher[]>([]);
-  const [teacherId, setTeacherId] = useState<number | null>(null);
+  const [teacherId, setTeacherId] = useState<string | null>(null);
   const [events, setEvents] = useState<EventInput[]>([]);
   const [modalLesson, setModalLesson] = useState<Lesson | null>(null);
 
@@ -27,7 +27,7 @@ export const ManagerCalendar = () => {
       .then((r) => r.json())
       .then((data: Teacher[]) => {
         setTeachers(data);
-        if (data.length > 0) setTeacherId(data[0].id);
+        if (data.length > 0) setTeacherId(String(data[0].id));
       });
   }, []);
 
@@ -55,7 +55,7 @@ export const ManagerCalendar = () => {
         <select
           id="teacher"
           value={teacherId ?? ''}
-          onChange={(e) => setTeacherId(Number(e.target.value))}
+          onChange={(e) => setTeacherId(e.target.value)}
           className="border p-1"
         >
           {teachers.map((t) => (

--- a/frontend/src/components/StudentCombobox.tsx
+++ b/frontend/src/components/StudentCombobox.tsx
@@ -1,14 +1,14 @@
 import { useEffect, useState } from 'react';
 
 export interface Student {
-  id: number;
+  id: string;
   name: string;
   email: string;
 }
 
 interface Props {
-  value: number | null;
-  onChange: (id: number | null) => void;
+  value: string | null;
+  onChange: (id: string | null) => void;
 }
 
 export const StudentCombobox = ({ value, onChange }: Props) => {
@@ -24,7 +24,7 @@ export const StudentCombobox = ({ value, onChange }: Props) => {
     <select
       className="border p-1"
       value={value ?? ''}
-      onChange={(e) => onChange(e.target.value ? Number(e.target.value) : null)}
+      onChange={(e) => onChange(e.target.value || null)}
     >
       <option value="">Select student</option>
       {students.map((s) => (

--- a/frontend/src/components/TeacherCalendar.tsx
+++ b/frontend/src/components/TeacherCalendar.tsx
@@ -5,7 +5,7 @@ import timeGridPlugin from '@fullcalendar/timegrid';
 import { type EventInput } from '@fullcalendar/core';
 
 interface Lesson {
-  id: number;
+  id: string;
   dateTime: string;
   duration: number;
   group?: { name: string };

--- a/frontend/src/components/TemplateDialog.tsx
+++ b/frontend/src/components/TemplateDialog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 export interface Template {
-  id?: number;
+  id?: string;
   code: string;
   lang: string;
   subject: string;

--- a/frontend/src/pages/StudentsPage.tsx
+++ b/frontend/src/pages/StudentsPage.tsx
@@ -23,7 +23,7 @@ export const StudentsPage = () => {
       s.email.toLowerCase().includes(search.toLowerCase())
   );
 
-  const remove = (id: number) => {
+  const remove = (id: string) => {
     fetch(`/api/students/${id}`, { method: 'DELETE' }).then(load);
   };
 

--- a/frontend/src/pages/TemplatesPage.tsx
+++ b/frontend/src/pages/TemplatesPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { Sidebar } from '../components/Sidebar';
-import { TemplateDialog, Template } from '../components/TemplateDialog';
+import { TemplateDialog } from '../components/TemplateDialog';
+import type { Template } from '../components/TemplateDialog';
 
 export const TemplatesPage = () => {
   const [templates, setTemplates] = useState<Template[]>([]);
@@ -15,7 +16,7 @@ export const TemplatesPage = () => {
 
   useEffect(load, []);
 
-  const remove = (id: number) => {
+  const remove = (id: string) => {
     fetch(`/api/templates/${id}`, { method: 'DELETE' }).then(load);
   };
 


### PR DESCRIPTION
## Summary
- switch frontend ID fields from `number` to `string`
- keep student selection working after type change
- adapt calendar components for string teacher IDs

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6844abe7a8b0832693bb67afd7a0800b