### PR TITLE
fix user mapper

### DIFF
--- a/backend/src/main/java/com/example/scheduletracker/mapper/UserMapper.java
+++ b/backend/src/main/java/com/example/scheduletracker/mapper/UserMapper.java
@@ -3,9 +3,12 @@ package com.example.scheduletracker.mapper;
 import com.example.scheduletracker.dto.UserDto;
 import com.example.scheduletracker.entity.User;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface UserMapper {
   UserDto toDto(User user);
+  @Mapping(target = "password", ignore = true)
+  @Mapping(target = "twoFaSecret", ignore = true)
   User toEntity(UserDto dto);
 }


### PR DESCRIPTION
## Summary
- ignore password and two-factor secret fields when mapping a `UserDto` to `User`

## Testing
- `./gradlew build --no-daemon` *(fails: `spotlessJavaCheck` violations)*
- `./gradlew sonar:scan --no-daemon` *(fails: task not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844b27d916c8326a4e4098dadfc9f54