### PR TITLE
Add unique constraint to notification_template

### DIFF
--- a/backend/src/main/java/com/example/scheduletracker/entity/NotificationTemplate.java
+++ b/backend/src/main/java/com/example/scheduletracker/entity/NotificationTemplate.java
@@ -5,7 +5,9 @@ import java.util.UUID;
 import org.hibernate.annotations.GenericGenerator;
 
 @Entity
-@Table(name = "notification_template")
+@Table(
+    name = "notification_template",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"code", "lang"}))
 public class NotificationTemplate {
   @Id
   @GeneratedValue(generator = "UUID")

--- a/backend/src/main/resources/db/migration/V5__notification_template_unique.sql
+++ b/backend/src/main/resources/db/migration/V5__notification_template_unique.sql
@@ -1,0 +1,2 @@
+ALTER TABLE notification_template
+    ADD CONSTRAINT notification_template_code_lang_uq UNIQUE (code, lang);

--- a/backend/src/test/java/com/example/scheduletracker/FlywaySchemaTest.java
+++ b/backend/src/test/java/com/example/scheduletracker/FlywaySchemaTest.java
@@ -28,5 +28,11 @@ public class FlywaySchemaTest {
             "SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'LESSON' AND COLUMN_NAME = 'GROUP_ID'",
             Integer.class);
     assertThat(colExists).isEqualTo(1);
+
+    Integer constraintCount =
+        jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM INFORMATION_SCHEMA.CONSTRAINTS WHERE TABLE_NAME = 'NOTIFICATION_TEMPLATE' AND CONSTRAINT_TYPE = 'UNIQUE'",
+            Integer.class);
+    assertThat(constraintCount).isEqualTo(1);
   }
 }


### PR DESCRIPTION
## Summary
- enforce unique template `code`+`lang` at DB level
- map `NotificationTemplate` with JPA unique constraint
- verify constraint in FlywaySchemaTest

## Testing
- `./backend/gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6844c180df2c8326b6f86cd45b3f1d5a