### PR TITLE
Fix JWT setup for Docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ openssl req -x509 -newkey rsa:2048 -nodes -keyout infra/nginx/certs/server.key -
 ```bash
 ./gradlew build
 cp $(ls build/libs/*.jar | grep -v plain | head -n 1) app.jar
+export JWT_SECRET=$(openssl rand -hex 32)  # или добавьте значение в файл .env
 cd ..
 docker compose -f infra/docker-compose.dev.yml up --build
 

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -18,6 +18,7 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: postgres
       DB_HOST: db
+      JWT_SECRET: ${JWT_SECRET}
     restart: unless-stopped
     ports:
       - "8080:8080"


### PR DESCRIPTION
## Summary
- expose JWT_SECRET in docker-compose
- document JWT secret setup in README

## Testing
- `npm run lint -s --prefix frontend`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6844c5cb3b6c8326b741a3c05fb2aa8d