### PR TITLE
Fix container startup with legacy path matcher

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 # Common properties (no active profile hard-coded)
+# Use legacy Ant path matcher for complex patterns in SpaController
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher


### PR DESCRIPTION
## Summary
- use legacy path matcher for SpaController patterns

## Testing
- `./gradlew spotlessCheck test`

------
https://chatgpt.com/codex/tasks/task_e_6844e613bd908326a72ea34b43e9a133