### PR TITLE
Fix container startup with default JWT secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,14 +94,16 @@ openssl req -x509 -newkey rsa:2048 -nodes -keyout infra/nginx/certs/server.key -
 ```bash
 ./gradlew build
 cp $(ls build/libs/*.jar | grep -v plain | head -n 1) app.jar
-export JWT_SECRET=$(openssl rand -hex 32)  # или добавьте значение в файл .env
+export JWT_SECRET=$(openssl rand -hex 32)  # опционально, иначе используется changeme
 cd ..
 docker compose -f infra/docker-compose.dev.yml up --build
+```
+Если переменная `JWT_SECRET` не задана, docker compose подставит `changeme`.
+Не используйте этот ключ в production.
 
 При запуске `nginx` отдельно используйте переменные окружения `APP_HOST` и
 `APP_PORT` для указания адреса backend-сервиса. Контейнер автоматически
 подставит их в `nginx.conf.template`.
-```
 
 После старта контейнеров веб-интерфейс доступен по адресу
 `https://localhost` (порт `443`). Обращения к `http://localhost` будут

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 # Common properties (no active profile hard-coded)
+# Use legacy Ant path matcher for complex patterns in SpaController
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -18,7 +18,7 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: postgres
       DB_HOST: db
-      JWT_SECRET: ${JWT_SECRET}
+      JWT_SECRET: ${JWT_SECRET:-changeme}
     restart: unless-stopped
     ports:
       - "8080:8080"


### PR DESCRIPTION
## Summary
- provide fallback JWT secret in docker-compose
- clarify docs about default secret for dev

## Testing
- `./gradlew spotlessCheck test`

------
https://chatgpt.com/codex/tasks/task_e_6844e613bd908326a72ea34b43e9a133