### PR TITLE
Build backend JAR inside Docker image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,13 +88,6 @@ jobs:
       run: ./gradlew build
       working-directory: backend
 
-    # 5. Переименовываем артефакт → app.jar (чтобы Dockerfile его нашёл)
-    - name: Prepare artifact
-      run: |
-        set -e
-        mkdir -p backend/build
-        JAR_FILE=$(ls backend/build/libs/*.jar | grep -v plain | head -n 1)
-        cp "$JAR_FILE" backend/build/app.jar
 
     - name: Generate test TLS certificate
       run: |
@@ -115,7 +108,7 @@ jobs:
           -v ${{ github.workspace }}/infra/nginx/certs:/etc/nginx/certs:ro \
           nginx:1.26 nginx -t -c /etc/nginx/nginx.conf
 
-    # 6. Копируем Dockerfile и docker-compose.yml на VPS (в корень /root/myapp)
+    # 5. Копируем Dockerfile и docker-compose.yml на VPS (в корень /root/myapp)
     - name: Copy infra files to VPS
       if: ${{ hashFiles('backend/Dockerfile', 'infra/docker-compose.dev.yml', 'infra/nginx/nginx.conf', 'infra/nginx/nginx.conf.template') != '' }}
       uses: appleboy/scp-action@v0.1.4
@@ -129,7 +122,7 @@ jobs:
         target: /root/myapp
         rm:     true
 
-    # 6.5. Убеждаемся, что каталог существует (на случай пропуска предыдущего шага)
+    # 5.5. Убеждаемся, что каталог существует (на случай пропуска предыдущего шага)
     - name: Ensure target directory
       uses: appleboy/ssh-action@v1.0.0
       with:
@@ -140,19 +133,8 @@ jobs:
         script: |
           mkdir -p /root/myapp
 
-    # 7. Копируем сам app.jar на VPS
-    - name: Copy app.jar to VPS
-      uses: appleboy/scp-action@v0.1.4
-      with:
-        host:       ${{ secrets.VPS_HOST }}
-        username:   ${{ secrets.VPS_USER }}
-        password:   ${{ secrets.VPS_PASSWORD }}
-        # port:     ${{ secrets.VPS_PORT }}
-        source:     backend/build/app.jar
-        target:     /root/myapp
-        strip_components: 2
 
-    # 8. Собираем Docker-образ и перезапускаем контейнер через SSH
+    # 7. Собираем Docker-образ и перезапускаем контейнер через SSH
     - name: Docker Compose up
       uses: appleboy/ssh-action@v1.0.0
       with:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,9 +1,19 @@
+# ---- Build stage -----------------------------------------------------------
+FROM gradle:8-jdk21 AS build
+WORKDIR /workspace
+COPY backend /workspace/backend
+WORKDIR /workspace/backend
+# Собираем исполняемый JAR без запуска тестов
+RUN ./gradlew bootJar --no-daemon
+RUN cp $(ls build/libs/*.jar | grep -v plain | head -n 1) app.jar
+
+# ---- Runtime stage ---------------------------------------------------------
 FROM eclipse-temurin:21-jre
 RUN apt-get update \
     && apt-get install -y --no-install-recommends postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
-COPY app.jar app.jar
+COPY --from=build /workspace/backend/app.jar app.jar
 # Скрипт ожидания доступности базы данных
 COPY scripts/wait-for-db.sh /wait-for-db.sh
 RUN chmod +x /wait-for-db.sh


### PR DESCRIPTION
## Summary
- build the Spring Boot JAR in a separate Docker stage
- copy the artifact to the runtime image
- remove manual artifact copying from the deploy workflow

## Testing
- `./gradlew test --no-daemon --console=plain` *(failed: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684570c0edd88326ae4d77894e262157