### PR TITLE
Add .env example and integrate with docker compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment file
+SPRING_PROFILES_ACTIVE=postgres
+DB_HOST=localhost
+DB_PORT=5432
+JWT_SECRET=changeme

--- a/README.md
+++ b/README.md
@@ -68,12 +68,13 @@
 
 ## Запуск в Docker
 
-Приложение использует профиль `postgres`, поэтому его нужно активировать
-через переменную `SPRING_PROFILES_ACTIVE`. Также контейнеру требуется адрес
-сервиса PostgreSQL в переменной `DB_HOST`. Если вы создавали контейнер БД по
-примеру выше, его имя `schedule-db`. Для связи контейнеров понадобится сеть
-`app-network`; создайте её при необходимости командой `docker network create
-app-network`. Запуск приложения выглядит так:
+Перед первым запуском скопируйте `.env.example` в `.env` и задайте значения
+`SPRING_PROFILES_ACTIVE`, `DB_HOST`, `DB_PORT` и `JWT_SECRET`. `docker compose`
+автоматически подхватит этот файл. Приложение использует профиль `postgres`,
+поэтому переменные по умолчанию подходят для локального запуска. Если вы
+создавали контейнер БД по примеру выше, его имя `schedule-db`. Для связи
+контейнеров понадобится сеть `app-network`; создайте её при необходимости
+командой `docker network create app-network`. Запуск приложения выглядит так:
 
 ```bash
 docker run --rm -it --network app-network \
@@ -94,12 +95,11 @@ openssl req -x509 -newkey rsa:2048 -nodes -keyout infra/nginx/certs/server.key -
 ```bash
 ./gradlew build
 cp $(ls build/libs/*.jar | grep -v plain | head -n 1) app.jar
-export JWT_SECRET=$(openssl rand -hex 32)  # опционально, иначе используется changeme
 cd ..
 docker compose -f infra/docker-compose.dev.yml up --build
 ```
-Если переменная `JWT_SECRET` не задана, docker compose подставит `changeme`.
-Не используйте этот ключ в production.
+Секрет `JWT_SECRET` можно сгенерировать командой `openssl rand -hex 32` и
+записать его в `.env`. Не используйте значение `changeme` в production.
 
 При запуске `nginx` отдельно используйте переменные окружения `APP_HOST` и
 `APP_PORT` для указания адреса backend-сервиса. Контейнер автоматически

--- a/backend/src/main/resources/application-postgres.properties
+++ b/backend/src/main/resources/application-postgres.properties
@@ -1,5 +1,5 @@
 # Production ("postgres" profile) properties
-spring.datasource.url=jdbc:postgresql://${DB_HOST:myapp-db-1}:5432/schedule
+spring.datasource.url=jdbc:postgresql://${DB_HOST:myapp-db-1}:${DB_PORT:5432}/schedule
 spring.datasource.username=postgres
 spring.datasource.password=postgres
 

--- a/backend/src/main/resources/application-postgres.yml
+++ b/backend/src/main/resources/application-postgres.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://${DB_HOST:localhost}:5432/schedule
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/schedule
     username: postgres
     password: postgres
   jpa:

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     ports:
-      - "5432:5432"
+      - "${DB_PORT:-5432}:5432"
   app:
     build:
       context: ..
@@ -16,8 +16,9 @@ services:
     depends_on:
       - db
     environment:
-      SPRING_PROFILES_ACTIVE: postgres
-      DB_HOST: db
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-postgres}
+      DB_HOST: ${DB_HOST:-db}
+      DB_PORT: ${DB_PORT:-5432}
       JWT_SECRET: ${JWT_SECRET:-changeme}
     restart: unless-stopped
     ports:


### PR DESCRIPTION
## Summary
- add `.env.example` with key environment variables
- configure docker compose to read variables from `.env`
- allow specifying DB_PORT in Spring configs
- update README with instructions to copy `.env.example`

## Testing
- `./backend/gradlew test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68457508b5f4832691a8d84a9a008692