### PR TITLE
Add container healthchecks and wait logic

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,5 +154,6 @@ jobs:
           docker compose -f infra/docker-compose.dev.yml down --remove-orphans
           docker compose -f infra/docker-compose.dev.yml build --no-cache
           docker compose -f infra/docker-compose.dev.yml up -d
+          docker compose -f infra/docker-compose.dev.yml wait db app
           docker compose -f infra/docker-compose.dev.yml ps
           docker compose -f infra/docker-compose.dev.yml logs app --tail=20

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,7 +10,7 @@ RUN cp $(ls build/libs/*.jar | grep -v plain | head -n 1) app.jar
 # ---- Runtime stage ---------------------------------------------------------
 FROM eclipse-temurin:21-jre
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends postgresql-client \
+    && apt-get install -y --no-install-recommends postgresql-client curl \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=build /workspace/backend/app.jar app.jar

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -9,24 +9,37 @@ services:
       POSTGRES_PASSWORD: postgres
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
   app:
     build:
       context: ..
       dockerfile: backend/Dockerfile
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       SPRING_PROFILES_ACTIVE: postgres
       DB_HOST: db
       JWT_SECRET: ${JWT_SECRET:-changeme}
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     ports:
       - "8080:8080"
 
   nginx:
     image: nginx:alpine
     depends_on:
-      - app
+      app:
+        condition: service_healthy
     restart: unless-stopped
     environment:
       APP_HOST: app
@@ -49,6 +62,7 @@ services:
     image: nginx/nginx-prometheus-exporter:1.1.0
     depends_on:
       - nginx
+    restart: unless-stopped
     command:
       - --nginx.scrape-uri=http://nginx/nginx_status
     ports:


### PR DESCRIPTION
## Summary
- add healthchecks for db and app in compose
- use service_healthy condition for dependent services
- install curl in runtime image
- wait for healthy containers in deploy workflow

## Testing
- `./gradlew test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845797cdf8c8326b9ff8bbed3c3bf62