### PR TITLE
Fix Docker build by setting gradlew executable

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,6 +3,8 @@ FROM gradle:8-jdk21 AS build
 WORKDIR /workspace
 COPY backend /workspace/backend
 WORKDIR /workspace/backend
+# Убеждаемся, что gradlew имеет права на исполнение
+RUN chmod +x gradlew
 # Собираем исполняемый JAR без запуска тестов
 RUN ./gradlew bootJar --no-daemon
 RUN cp $(ls build/libs/*.jar | grep -v plain | head -n 1) app.jar


### PR DESCRIPTION
## Summary
- ensure `gradlew` is executable in backend Dockerfile

## Testing
- `./gradlew --version`
- `./gradlew test` *(fails: `Calculating task graph as no cached configuration is available for tasks: test`)*

------
https://chatgpt.com/codex/tasks/task_e_68457d670ef08326a5e318c1d7f16f31