### PR TITLE
Add Compose profiles

### DIFF
--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -16,6 +16,7 @@ services:
       retries: 5
     restart: unless-stopped
   app:
+    profiles: ["prod"]
     build:
       context: ..
       dockerfile: backend/Dockerfile
@@ -36,6 +37,33 @@ services:
     ports:
       - "8080:8080"
 
+  app-dev:
+    profiles: ["dev"]
+    build:
+      context: ..
+      dockerfile: backend/Dockerfile
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-postgres}
+      DB_HOST: ${DB_HOST:-db}
+      DB_PORT: ${DB_PORT:-5432}
+      JWT_SECRET: ${JWT_SECRET:-changeme}
+    entrypoint: ["/wait-for-db.sh"]
+    command: ["/workspace/scripts/start-dev.sh"]
+    working_dir: /workspace/backend
+    volumes:
+      - ../:/workspace
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    ports:
+      - "8080:8080"
+
   nginx:
     image: nginx:alpine
     depends_on:
@@ -43,7 +71,7 @@ services:
         condition: service_healthy
     restart: unless-stopped
     environment:
-      APP_HOST: app
+      APP_HOST: ${APP_HOST:-app}
       APP_PORT: 8080
     entrypoint: >
       /bin/sh -c "


### PR DESCRIPTION
## Summary
- add dev/prod profiles to docker-compose.dev.yml
- mount sources and dev command for live reload
- mention how to use profiles in README

## Testing
- `./backend/gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68457ef9234c8326aff262e18241f968