### PR TITLE
Fix docker compose profile in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -153,9 +153,9 @@ jobs:
           docker ps -aqf "name=myapp-db-1" | xargs -r docker rm -f
           # if any other container is using port 8080, force remove it
           docker ps -q --filter "publish=8080" | xargs -r docker rm -f
-          docker compose -f infra/docker-compose.dev.yml down --remove-orphans
-          docker compose -f infra/docker-compose.dev.yml build --no-cache
-          docker compose -f infra/docker-compose.dev.yml up -d
-          docker compose -f infra/docker-compose.dev.yml wait db app
-          docker compose -f infra/docker-compose.dev.yml ps
-          docker compose -f infra/docker-compose.dev.yml logs app --tail=20
+          docker compose --profile prod -f infra/docker-compose.dev.yml down --remove-orphans
+          docker compose --profile prod -f infra/docker-compose.dev.yml build --no-cache
+          docker compose --profile prod -f infra/docker-compose.dev.yml up -d
+          docker compose --profile prod -f infra/docker-compose.dev.yml wait db app
+          docker compose --profile prod -f infra/docker-compose.dev.yml ps
+          docker compose --profile prod -f infra/docker-compose.dev.yml logs app --tail=20


### PR DESCRIPTION
## Summary
- ensure deployment includes the production profile when running docker compose

## Testing
- `./gradlew test`
- `npm ci && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68458992d6dc8326b5164c937afe12b3