### PR TITLE
Add Spring Boot actuator and Prometheus support

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -30,6 +30,8 @@ dependencies {
     implementation(libs.org.springframework.boot.spring.boot.starter.validation)
     implementation(libs.org.springframework.boot.spring.boot.starter.quartz)
     implementation(libs.org.springframework.boot.spring.boot.starter.mail)
+    implementation(libs.org.springframework.boot.spring.boot.starter.actuator)
+    implementation(libs.io.micrometer.micrometer.registry.prometheus)
     implementation(libs.org.apache.poi.poi.ooxml)
     implementation(libs.org.mapstruct.mapstruct)
     implementation(libs.otp.java)

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -27,6 +27,8 @@ mapstruct = "1.6.0"
 apache-poi = "5.2.5"
 otp-java = "2.1.0"
 aerogear-otp = "1.0.0"
+org-springframework-boot-spring-boot-starter-actuator = "3.5.0"
+io-micrometer-micrometer-registry-prometheus = "1.15.0"
 
 [libraries]
 com-h2database-h2 = { module = "com.h2database:h2", version.ref = "com-h2database-h2" }
@@ -55,3 +57,5 @@ org-springframework-boot-spring-boot-starter-mail = { module = "org.springframew
 org-apache-poi-poi-ooxml = { module = "org.apache.poi:poi-ooxml", version.ref = "apache-poi" }
 otp-java = { module = "com.github.bastiaanjansen:otp-java", version.ref = "otp-java" }
 aerogear-otp = { module = "org.jboss.aerogear:aerogear-otp-java", version.ref = "aerogear-otp" }
+org-springframework-boot-spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator", version.ref = "org-springframework-boot-spring-boot-starter-actuator" }
+io-micrometer-micrometer-registry-prometheus = { module = "io.micrometer:micrometer-registry-prometheus", version.ref = "io-micrometer-micrometer-registry-prometheus" }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,3 +7,9 @@ telegram:
 
 jwt:
   secret: ${JWT_SECRET:changeme}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus


### PR DESCRIPTION
## Summary
- add aliases for actuator and micrometer-registry-prometheus
- include them in backend build
- expose management endpoints

## Testing
- `./backend/gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684590dd6ad88326811895a78a0870c4