### PR TITLE
Remove unused compose version

### DIFF
--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   db:
     # Fresh PostgreSQL instance


### PR DESCRIPTION
## Summary
- drop the Compose version line from the development config

## Testing
- `docker compose -f infra/docker-compose.dev.yml config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845929e8c0c83268526c62b5f10a766