### PR TITLE
Update service health docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,20 @@ make up
 ```
 Остановить контейнеры можно командой `make down`.
 
+Проверить здоровье приложения можно запросом к эндпоинту `/actuator/health`:
+```bash
+curl -f http://localhost:8080/actuator/health
+```
+Метрики Spring Boot доступны на `/actuator/prometheus` и могут быть
+собраны Prometheus:
+```bash
+curl http://localhost:8080/actuator/prometheus
+```
+
 После запуска метрики Nginx доступны на `http://localhost:9114/metrics`.
 Экспортер считывает данные со страницы `/nginx_status` внутри контейнера.
+Добавьте оба адреса в конфигурацию Prometheus, чтобы собирать показатели от
+приложения и `nginx-exporter`.
 
 
 

--- a/docs/RUNBOOK_NGINX.md
+++ b/docs/RUNBOOK_NGINX.md
@@ -26,3 +26,17 @@
 ## Неожиданный перезапуск
 1. Проверить логи автоматизации CI/CD.
 2. Удостовериться в успешной валидации конфигурации.
+
+## Проверка эндпоинтов
+1. Запросите `/actuator/health` приложения, чтобы убедиться в его работоспособности:
+   ```bash
+   curl -f http://localhost:8080/actuator/health
+   ```
+2. Убедитесь, что метрики доступны по `/actuator/prometheus`:
+   ```bash
+   curl http://localhost:8080/actuator/prometheus
+   ```
+3. Метрики Nginx предоставляет контейнер `nginx-exporter` на порту `9114`:
+   ```bash
+   curl http://localhost:9114/metrics
+   ```


### PR DESCRIPTION
## Summary
- document new /actuator endpoints in README
- explain Prometheus scraping including nginx-exporter
- add runbook instructions for checking health and metrics endpoints

## Testing
- `./backend/gradlew test` *(fails: Directory '/workspace/trash' does not contain a Gradle build)*
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68459317f0388326b73916be54872a32