### PR TITLE
Add prometheus service

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,14 @@ curl -f http://localhost:8080/actuator/health
 curl http://localhost:8080/actuator/prometheus
 ```
 
+
 После запуска метрики Nginx доступны на `http://localhost:9114/metrics`.
 Экспортер считывает данные со страницы `/nginx_status` внутри контейнера.
-Добавьте оба адреса в конфигурацию Prometheus, чтобы собирать показатели от
-приложения и `nginx-exporter`.
+
+Инфраструктура включает сервис `prometheus`, который читает конфигурацию из
+`infra/prometheus/prometheus.yml` и автоматически опрашивает приложение и
+`nginx-exporter`. Веб‑интерфейс Prometheus доступен на
+`http://localhost:9090`.
 
 
 

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -95,3 +95,11 @@ services:
       - --nginx.scrape-uri=http://nginx/nginx_status
     ports:
       - "9114:9113"
+
+  prometheus:
+    image: prom/prometheus:latest
+    restart: unless-stopped
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"

--- a/infra/prometheus/prometheus.yml
+++ b/infra/prometheus/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'schedule-app'
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['app:8080', 'app-dev:8080']
+
+  - job_name: 'nginx'
+    static_configs:
+      - targets: ['nginx-exporter:9113']


### PR DESCRIPTION
## Summary
- run Prometheus alongside the stack
- scrape app and nginx-exporter metrics
- document metrics collection in README

## Testing
- `./gradlew test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845965ff88c8326ab6235302c7949c3