### PR TITLE
Fix Prometheus mounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ curl http://localhost:8080/actuator/prometheus
 Экспортер считывает данные со страницы `/nginx_status` внутри контейнера.
 
 Инфраструктура включает сервис `prometheus`, который читает конфигурацию из
-`infra/prometheus/prometheus.yml` и автоматически опрашивает приложение и
+каталога `infra/prometheus` и автоматически опрашивает приложение и
 `nginx-exporter`. Веб‑интерфейс Prometheus доступен на
 `http://localhost:9090`.
 

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -100,6 +100,6 @@ services:
     image: prom/prometheus:latest
     restart: unless-stopped
     volumes:
-      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus:/etc/prometheus:ro
     ports:
       - "9090:9090"


### PR DESCRIPTION
## Summary
- fix path for Prometheus config mount
- document new directory in README

## Testing
- `./gradlew test --no-daemon --quiet` *(fails: Command timed out)*

------
https://chatgpt.com/codex/tasks/task_e_68458f1965a08326961f8bc816467871