### PR TITLE
Fix healthcheck timeout during docker compose up

### DIFF
--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -12,7 +12,7 @@ services:
       test: ["CMD", "pg_isready", "-U", "postgres"]
       interval: 10s
       timeout: 5s
-      retries: 5
+    retries: 10
     restart: unless-stopped
   app:
     profiles: ["prod"]
@@ -32,7 +32,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       interval: 10s
       timeout: 5s
-      retries: 5
+    retries: 10
     ports:
       - "8080:8080"
 
@@ -59,7 +59,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       interval: 10s
       timeout: 5s
-      retries: 5
+    retries: 10
     ports:
       - "8080:8080"
 


### PR DESCRIPTION
## Summary
- increase retry count in docker-compose healthchecks

## Testing
- `./backend/gradlew test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845aa06c9148326b2a945f21e44bad1