### PR TITLE
Document JWT secret setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,4 @@
 SPRING_PROFILES_ACTIVE=postgres
 DB_HOST=localhost
 DB_PORT=5432
-JWT_SECRET=changeme
+JWT_SECRET=<secure-random-string>

--- a/README.md
+++ b/README.md
@@ -70,8 +70,10 @@
 
 ## Запуск в Docker
 
-1. Скопируйте `.env.example` в `.env` и при необходимости измените
-   `SPRING_PROFILES_ACTIVE`, `DB_HOST`, `DB_PORT` и `JWT_SECRET`.
+1. Скопируйте `.env.example` в `.env`. Обязательно задайте
+   переменную `JWT_SECRET` случайной строкой длиной не менее 32 байт,
+   например `openssl rand -hex 32`.
+   При необходимости измените `SPRING_PROFILES_ACTIVE`, `DB_HOST` и `DB_PORT`.
    Файл автоматически читается `docker compose`.
 2. Создайте сертификат для Nginx:
 
@@ -237,7 +239,11 @@ cd frontend && npm run lint
 
 ## JWT
 
-Приложение подписывает JWT секретом из переменной окружения `JWT_SECRET`. По умолчанию используется значение `changeme`, поэтому для production окружений обязательно задайте собственный ключ.
+Приложение подписывает JWT секретом из переменной окружения `JWT_SECRET`.
+В `application.yml` он задан как `${JWT_SECRET:changeme}`, поэтому
+в production его нужно обязательно переопределить и использовать
+случайную строку не менее 32 байт,
+например `openssl rand -hex 32`.
 
 ## Backup
 


### PR DESCRIPTION
## Summary
- show placeholder for JWT secret in `.env.example`
- explain how to generate a strong secret in README
- clarify that the default `changeme` in `application.yml` must be overridden

## Testing
- `./backend/gradlew test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6845affb5b7c8326a9e7d363f2e40fc4