### PR TITLE
Require JWT_SECRET for docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@
    переменную `JWT_SECRET` случайной строкой длиной не менее 32 байт,
    например `openssl rand -hex 32`.
    При необходимости измените `SPRING_PROFILES_ACTIVE`, `DB_HOST` и `DB_PORT`.
-   Файл автоматически читается `docker compose`.
+   Файл автоматически читается `docker compose`. Если переменная не
+   задана, `docker compose` завершится ошибкой `JWT_SECRET: set JWT_SECRET in .env`.
 2. Создайте сертификат для Nginx:
 
    ```bash
@@ -243,7 +244,9 @@ cd frontend && npm run lint
 В `application.yml` он задан как `${JWT_SECRET:changeme}`, поэтому
 в production его нужно обязательно переопределить и использовать
 случайную строку не менее 32 байт,
-например `openssl rand -hex 32`.
+например `openssl rand -hex 32`. Файл
+`infra/docker-compose.dev.yml` требует эту переменную, поэтому запуск
+контейнеров завершится ошибкой, если `JWT_SECRET` не задан.
 
 ## Backup
 

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -26,7 +26,7 @@ services:
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-postgres}
       DB_HOST: ${DB_HOST:-db}
       DB_PORT: ${DB_PORT:-5432}
-      JWT_SECRET: ${JWT_SECRET:-changeme}
+      JWT_SECRET: ${JWT_SECRET:?set JWT_SECRET in .env}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
@@ -48,7 +48,7 @@ services:
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-postgres}
       DB_HOST: ${DB_HOST:-db}
       DB_PORT: ${DB_PORT:-5432}
-      JWT_SECRET: ${JWT_SECRET:-changeme}
+      JWT_SECRET: ${JWT_SECRET:?set JWT_SECRET in .env}
     entrypoint: ["/wait-for-db.sh"]
     command: ["/workspace/scripts/start-dev.sh"]
     working_dir: /workspace/backend


### PR DESCRIPTION
## Summary
- enforce JWT_SECRET env var in docker-compose.dev.yml
- describe the required variable in README

## Testing
- `./backend/gradlew test` *(fails: Directory does not contain a Gradle build)*
- `npm run lint` *(fails: cannot find '@eslint/js')*
- `docker compose -f infra/docker-compose.dev.yml config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845b817c9208326b58702764fb5fd04