### PR TITLE
Fix JWT test secret

### DIFF
--- a/backend/src/test/java/com/example/scheduletracker/config/jwt/JwtUtilsTest.java
+++ b/backend/src/test/java/com/example/scheduletracker/config/jwt/JwtUtilsTest.java
@@ -11,7 +11,7 @@ class JwtUtilsTest {
 
   @BeforeEach
   void setup() {
-    utils = new JwtUtils("testsecret");
+    utils = new JwtUtils("0123456789abcdef0123456789abcdef");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- use a stronger 32-byte secret in JwtUtils tests

## Testing
- `./gradlew test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6845b9b8f44c8326810fb0b5bdd47ae1