### PR TITLE
Add secret validation to JwtUtils

### DIFF
--- a/backend/src/main/java/com/example/scheduletracker/config/jwt/JwtUtils.java
+++ b/backend/src/main/java/com/example/scheduletracker/config/jwt/JwtUtils.java
@@ -14,7 +14,12 @@ public class JwtUtils {
   private final long expirationMs = 3600_000; // 1h
 
   public JwtUtils(@Value("${jwt.secret}") String secret) {
-    this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    byte[] bytes = secret.getBytes(StandardCharsets.UTF_8);
+    if (bytes.length < 32) {
+      throw new IllegalArgumentException(
+          "JWT secret key must be at least 32 bytes long for HS256 algorithm");
+    }
+    this.key = Keys.hmacShaKeyFor(bytes);
   }
 
   public String generateToken(String username, String role) {

--- a/backend/src/test/java/com/example/scheduletracker/config/jwt/JwtUtilsTest.java
+++ b/backend/src/test/java/com/example/scheduletracker/config/jwt/JwtUtilsTest.java
@@ -21,4 +21,11 @@ class JwtUtilsTest {
     assertEquals("alice", claims.getSubject());
     assertEquals("MANAGER", claims.get("role"));
   }
+
+  @Test
+  void insecureSecretThrowsException() {
+    IllegalArgumentException ex =
+        assertThrows(IllegalArgumentException.class, () -> new JwtUtils("weak"));
+    assertTrue(ex.getMessage().contains("32 bytes"));
+  }
 }


### PR DESCRIPTION
## Summary
- ensure JWT secret key is at least 32 bytes
- test new validation behavior

## Testing
- `./gradlew spotlessApply`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6845bbdb89a88326ae52196c6a55ea10