### PR TITLE
Fix compose retries

### DIFF
--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -12,7 +12,7 @@ services:
       test: ["CMD", "pg_isready", "-U", "postgres"]
       interval: 10s
       timeout: 5s
-    retries: 10
+      retries: 10
     restart: unless-stopped
   app:
     profiles: ["prod"]
@@ -33,7 +33,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       interval: 10s
       timeout: 5s
-    retries: 10
+      retries: 10
     ports:
       - "8080:8080"
 
@@ -61,7 +61,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       interval: 10s
       timeout: 5s
-    retries: 10
+      retries: 10
     ports:
       - "8080:8080"
 


### PR DESCRIPTION
## Summary
- adjust `retries` indentation in Docker Compose healthchecks

## Testing
- `./backend/gradlew test` *(fails: Directory '/workspace/trash' does not contain a Gradle build)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6845c49abf7883268b717a49672f2616