### PR TITLE
Fix Prometheus config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ curl http://localhost:8080/actuator/prometheus
 Экспортер считывает данные со страницы `/nginx_status` внутри контейнера.
 
 Инфраструктура включает сервис `prometheus`, который читает конфигурацию из
-каталога `infra/prometheus` и автоматически опрашивает приложение и
+файла `infra/prometheus/prometheus.yml` и автоматически опрашивает приложение и
 `nginx-exporter`. Веб‑интерфейс Prometheus доступен на
 `http://localhost:9090`.
 

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -102,6 +102,6 @@ services:
     image: prom/prometheus:latest
     restart: unless-stopped
     volumes:
-      - ./prometheus:/etc/prometheus:ro
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
     ports:
       - "9090:9090"


### PR DESCRIPTION
## Summary
- mount Prometheus config file instead of directory in docker-compose
- update README to reference the config file

## Testing
- `./gradlew test` *(fails: Directory '/workspace/trash' does not contain a Gradle build)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6845d58f84908326adfb145096bcc937