### PR TITLE
Fix prometheus volume path

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ curl http://localhost:8080/actuator/prometheus
 Экспортер считывает данные со страницы `/nginx_status` внутри контейнера.
 
 Инфраструктура включает сервис `prometheus`, который читает конфигурацию из
-файла `infra/prometheus/prometheus.yml` и автоматически опрашивает приложение и
+каталога `infra/prometheus` и автоматически опрашивает приложение и
 `nginx-exporter`. Веб‑интерфейс Prometheus доступен на
 `http://localhost:9090`.
 

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -102,6 +102,6 @@ services:
     image: prom/prometheus:latest
     restart: unless-stopped
     volumes:
-      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus:/etc/prometheus
     ports:
       - "9090:9090"


### PR DESCRIPTION
## Summary
- mount full prometheus dir in compose
- document prometheus directory

## Testing
- `./backend/gradlew test` *(fails: Directory '/workspace/trash' does not contain a Gradle build)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `docker compose -f infra/docker-compose.dev.yml up -d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845db94535483269097102bcc8d4dd1