### PR TITLE
Fix Prometheus volume path

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,9 @@ curl http://localhost:8080/actuator/prometheus
 
 Инфраструктура включает сервис `prometheus`, который читает конфигурацию из
 каталога `infra/prometheus` и автоматически опрашивает приложение и
-`nginx-exporter`. Веб‑интерфейс Prometheus доступен на
-`http://localhost:9090`.
+`nginx-exporter`. Запускайте `docker compose -f infra/docker-compose.dev.yml`
+из корня проекта, чтобы Docker корректно смонтировал каталог. Веб‑интерфейс
+Prometheus доступен на `http://localhost:9090`.
 
 
 

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -102,6 +102,6 @@ services:
     image: prom/prometheus:latest
     restart: unless-stopped
     volumes:
-      - ./prometheus:/etc/prometheus
+      - ./infra/prometheus:/etc/prometheus
     ports:
       - "9090:9090"


### PR DESCRIPTION
## Summary
- mount infra/prometheus when starting Prometheus
- clarify in README that docker compose should be run from repo root so the Prometheus config directory resolves correctly

## Testing
- `COMPOSE_PROFILES=prod docker compose -f infra/docker-compose.dev.yml up -d` *(fails: cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6845dfe8bd248326ae9c79d14c93ea46