### PR TITLE
Fix prometheus config volume path

### DIFF
--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -102,6 +102,6 @@ services:
     image: prom/prometheus:latest
     restart: unless-stopped
     volumes:
-      - ./infra/prometheus:/etc/prometheus
+      - ./prometheus:/etc/prometheus
     ports:
       - "9090:9090"


### PR DESCRIPTION
## Summary
- fix Prometheus config path in `docker-compose.dev.yml`

## Testing
- `docker compose -f infra/docker-compose.dev.yml up -d` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845e68d60b0832695f4d5ae6e2061ba