### PR TITLE
Align nginx with compose profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,16 @@
    Dockerfile собирает JAR внутри образа, поэтому Gradle на хосте не требуется.
 4. Для остановки используйте `make down`, логи можно смотреть через `make logs`.
 
+При необходимости можно обойтись без Makefile и запустить `docker compose` напрямую:
+
+```bash
+docker compose -f infra/docker-compose.dev.yml up -d
+COMPOSE_PROFILES=dev docker compose -f infra/docker-compose.dev.yml up -d
+```
+
 Контейнер `app` предназначен для production-профиля, а `app-dev` активируется
-при запуске с профилем `dev`. Это упрощает локальную отладку.
+при запуске с профилем `dev`. Это упрощает локальную отладку. Контейнер `nginx`
+запускается только в профиле `prod` и автоматически ждёт готовности бэкенда.
 
 При запуске `nginx` отдельно задайте `APP_HOST` и `APP_PORT` для указания адреса
 бэкенда. Контейнер подставит их в `nginx.conf.template`.

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -66,6 +66,7 @@ services:
       - "8080:8080"
 
   nginx:
+    profiles: ["prod"]
     image: nginx:alpine
     depends_on:
       app:
@@ -89,6 +90,7 @@ services:
       - "443:443"
 
   nginx-exporter:
+    profiles: ["prod"]
     image: nginx/nginx-prometheus-exporter:1.1.0
     depends_on:
       - nginx


### PR DESCRIPTION
## Summary
- only start nginx and exporter for prod profile
- clarify manual `docker compose` usage

## Testing
- `./backend/gradlew test` *(fails: Directory '/workspace/trash' does not contain a Gradle build)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6845f519cbcc8326a040962c73f54c31