### PR TITLE
Fix docker compose down target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ up:
 	docker compose -f $(COMPOSE_FILE) up -d
 
 down:
-	docker compose -f $(COMPOSE_FILE) down
+       docker compose -f infra/docker-compose.yml down --remove-orphans
 
 logs:
 	docker compose -f $(COMPOSE_FILE) logs -f


### PR DESCRIPTION
## Summary
- update `down` make target to remove orphans

## Testing
- `./backend/gradlew test` *(fails: Directory `/workspace/trash` does not contain a Gradle build)*
- `npm run lint` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684615d3a3fc8326bfbf138eb2732b6e