### PR TITLE
Update README compose usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@
    make down
    ```
 
+Перед повторным запуском остановите предыдущие контейнеры:
+
+```bash
+make down
+# или
+docker compose down --remove-orphans
+```
+
+Статус контейнеров можно проверить командой `docker compose ps`.
+Убедитесь, что порт `8080` свободен: `lsof -i :8080` или `docker ps`.
+
    Dockerfile собирает JAR внутри образа, поэтому Gradle на хосте не требуется.
    Логи можно смотреть через `make logs`. При необходимости можно запустить
    `docker compose -f infra/docker-compose.yml up -d` напрямую без Makefile.


### PR DESCRIPTION
## Summary
- add short section on restarting containers and verifying ports

## Testing
- `./backend/gradlew test --no-daemon`
- `npm install`
- `cd frontend && npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846197b7cf883269d8f651a1d0177cc