### PR TITLE
Fix missing script in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,7 +123,7 @@ jobs:
         # port:     ${{ secrets.VPS_PORT }}
         # Передаём на сервер не только Dockerfile и compose, но и исходники
         # бэкенда, чтобы Docker смог собрать jar внутри контейнера
-        source: "backend,infra/docker-compose.yml,infra/.env.example,scripts/wait-for-db.sh,infra/nginx/nginx.conf"
+        source: "backend,infra/docker-compose.yml,infra/.env.example,scripts/wait-for-db.sh,scripts/start-dev.sh,infra/nginx/nginx.conf"
         target: ${{ env.DEPLOY_DIR }}
         rm:     true
 


### PR DESCRIPTION
## Summary
- include `scripts/start-dev.sh` in scp sources so Docker build can copy it

## Testing
- `./backend/gradlew -p backend test`

------
https://chatgpt.com/codex/tasks/task_e_6846309e95bc8326a0c7d7b461c2ef6b