### PR TITLE
Fix bootRun startup

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,7 +10,7 @@ RUN ./gradlew bootJar --no-daemon
 RUN cp $(ls build/libs/*.jar | grep -v plain | head -n 1) app.jar
 
 # ---- Runtime stage ---------------------------------------------------------
-FROM eclipse-temurin:21-jre
+FROM eclipse-temurin:21-jdk
 RUN apt-get update \
     && apt-get install -y --no-install-recommends postgresql-client curl \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- fix Dockerfile runtime image so Gradle can compile code during `bootRun`

## Testing
- `./backend/gradlew test`
- `cd frontend && npm install --silent && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684633fd03e48326837744bcf6b2c45c