### PR TITLE
Fix bootRun startup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,7 +123,7 @@ jobs:
         # port:     ${{ secrets.VPS_PORT }}
         # Передаём на сервер не только Dockerfile и compose, но и исходники
         # бэкенда, чтобы Docker смог собрать jar внутри контейнера
-        source: "backend,infra/docker-compose.yml,infra/.env.example,scripts/wait-for-db.sh,scripts/start-dev.sh,infra/nginx/nginx.conf"
+        source: "backend,infra/docker-compose.yml,infra/.env.example,scripts/wait-for-db.sh,infra/nginx/nginx.conf"
         target: ${{ env.DEPLOY_DIR }}
         rm:     true
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,7 +10,7 @@ RUN ./gradlew bootJar --no-daemon
 RUN cp $(ls build/libs/*.jar | grep -v plain | head -n 1) app.jar
 
 # ---- Runtime stage ---------------------------------------------------------
-FROM eclipse-temurin:21-jre
+FROM eclipse-temurin:21-jdk
 RUN apt-get update \
     && apt-get install -y --no-install-recommends postgresql-client curl \
     && rm -rf /var/lib/apt/lists/*

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -28,11 +28,6 @@ services:
       DB_HOST: ${DB_HOST:-db}
       DB_PORT: ${DB_PORT:-5432}
       JWT_SECRET: ${JWT_SECRET}
-    entrypoint: ["/wait-for-db.sh"]
-    command: ["/start-dev.sh"]
-    working_dir: /workspace/backend
-    volumes:
-      - ../:/workspace
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]


### PR DESCRIPTION
## Summary
- fix Dockerfile runtime image so Gradle can compile code during `bootRun`
- run the built JAR in compose instead of bootRun

## Testing
- `./backend/gradlew test`
- `cd frontend && npm install --silent && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684633fd03e48326837744bcf6b2c45c