### PR TITLE
Fix missing start-dev script in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,7 +123,7 @@ jobs:
         # port:     ${{ secrets.VPS_PORT }}
         # Передаём на сервер не только Dockerfile и compose, но и исходники
         # бэкенда, чтобы Docker смог собрать jar внутри контейнера
-        source: "backend,infra/docker-compose.yml,infra/.env.example,scripts/wait-for-db.sh,infra/nginx/nginx.conf"
+        source: "backend,infra/docker-compose.yml,infra/.env.example,scripts/wait-for-db.sh,scripts/start-dev.sh,infra/nginx/nginx.conf"
         target: ${{ env.DEPLOY_DIR }}
         rm:     true
 


### PR DESCRIPTION
## Summary
- ensure `scripts/start-dev.sh` is sent to the VPS when deploying

## Testing
- `./gradlew test --no-daemon --console plain`

------
https://chatgpt.com/codex/tasks/task_e_68463c4cfd608326b501e29da5d48092