### PR TITLE
Configure API proxy for dev server

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8080',
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- enable Vite dev proxy to forward `/api` to backend

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6846aeaf33b08326ba897fb355c22d1c