### PR TITLE
Add email verification with tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,16 @@
    - Установите JDK 21. На Linux можно установить пакет `openjdk-21-jdk`.
 2. **Gradle**
    - Используйте Gradle 8.14 или запускайте через прилагаемый скрипт `./backend/gradlew`.
-3. **Node.js**
+3. **Git hooks**
+   - Для автoформатирования Java-кода выполните `git config core.hooksPath scripts/git-hooks`.
+   - При коммите будет запускаться `./backend/gradlew spotlessApply`.
+4. **Node.js**
    - Use Node 20 or 22 as in the CI matrix.
    - Run `npm install` (or `npm ci`) before any npm script (`npm run build`, `npm run lint`, `npm run dev`).
    - Проверить стиль кода можно командой `cd frontend && npm run lint`.
    - Большинство ошибок форматирования исправляется автоматически
      через `cd frontend && npm run lint:fix`.
-4. **PostgreSQL**
+5. **PostgreSQL**
    - Приложение ожидает базу `schedule` с пользователем `postgres` и паролем `postgres`.
    - Быстрый вариант через Docker:
      ```bash
@@ -35,7 +38,7 @@
       `postgres` не активирован, используется встроенная база H2.
     - Для миграций используется Flyway **11.9.1**, что обеспечивает поддержку
       PostgreSQL 16.2.
-5. **Сборка и запуск backend**
+6. **Сборка и запуск backend**
    - Сборка: `./backend/gradlew build`
    - Запуск: `./backend/gradlew bootRun`
    - Приложение слушает порт `8080`. Убедитесь, что этот порт свободен
@@ -44,17 +47,17 @@
      Требуется подключение к интернету или локальный кеш артефактов.
    - В проект подключен модуль `spring-boot-starter-validation`,
      поэтому запросы валидируются через Bean Validation.
-6. **Запуск тестов**
+7. **Запуск тестов**
    - Выполните `./backend/gradlew test`.
 
-7. **Сборка CSS**
+8. **Сборка CSS**
    - Выполните `npm install` (или `npm ci`) из корня репозитория.
    - Для обновления стилей Tailwind запустите `npm run build` из корня
      репозитория. Результат появится в `backend/src/main/resources/static`.
    - При деплое workflow GitHub Actions автоматически выполняет эти
      команды, поэтому вручную собирать CSS не требуется.
 
-8. **Прокси**
+9. **Прокси**
    - Для получения зависимостей может потребоваться сетевой прокси.
      Укажите его хост и порт в переменных окружения
      `PROXY_HOST` и `PROXY_PORT` (а также `HTTP_PROXY` и `HTTPS_PROXY`

--- a/backend/src/main/java/com/example/scheduletracker/config/DataInitializer.java
+++ b/backend/src/main/java/com/example/scheduletracker/config/DataInitializer.java
@@ -32,7 +32,8 @@ public class DataInitializer implements ApplicationRunner {
               passwordEncoder.encode(rawPassword),
               role,
               totpService.generateSecret(),
-              false);
+              false,
+              true);
       userRepository.save(user);
     }
   }

--- a/backend/src/main/java/com/example/scheduletracker/controller/AuthController.java
+++ b/backend/src/main/java/com/example/scheduletracker/controller/AuthController.java
@@ -6,10 +6,14 @@ import com.example.scheduletracker.dto.LoginRequest;
 import com.example.scheduletracker.dto.SignupRequest;
 import com.example.scheduletracker.dto.SignupResponse;
 import com.example.scheduletracker.entity.User;
+import com.example.scheduletracker.entity.VerificationToken;
+import com.example.scheduletracker.repository.VerificationTokenRepository;
+import com.example.scheduletracker.service.NotificationService;
 import com.example.scheduletracker.service.UserService;
 import com.example.scheduletracker.service.security.TotpService;
 import jakarta.validation.Valid;
 import java.util.Optional;
+import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -24,16 +28,22 @@ public class AuthController {
   private final JwtUtils jwtUtils;
   private final UserService userService;
   private final TotpService totpService;
+  private final NotificationService notificationService;
+  private final VerificationTokenRepository tokenRepository;
 
   public AuthController(
       AuthenticationManager authManager,
       JwtUtils jwtUtils,
       UserService userService,
-      TotpService totpService) {
+      TotpService totpService,
+      NotificationService notificationService,
+      VerificationTokenRepository tokenRepository) {
     this.authManager = authManager;
     this.jwtUtils = jwtUtils;
     this.userService = userService;
     this.totpService = totpService;
+    this.notificationService = notificationService;
+    this.tokenRepository = tokenRepository;
   }
 
   @PostMapping("/login")
@@ -43,6 +53,9 @@ public class AuthController {
             new UsernamePasswordAuthenticationToken(req.username(), req.password()));
     String username = auth.getName();
     User user = userService.findByUsername(username).orElseThrow();
+    if (!user.isActive()) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
     if (user.isTwoFaEnabled() && !totpService.verifyCode(user.getTwoFaSecret(), req.code())) {
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
     }
@@ -66,8 +79,28 @@ public class AuthController {
             req.password(),
             User.Role.valueOf(roleName.toUpperCase()),
             secret,
+            false,
             false);
     userService.save(user);
+    UUID token = java.util.UUID.randomUUID();
+    tokenRepository.save(new VerificationToken(token, user));
+    notificationService.sendEmail(
+        username, "Verify account", "/api/auth/verify?token=" + token.toString());
     return ResponseEntity.status(HttpStatus.CREATED).body(new SignupResponse(secret));
+  }
+
+  @GetMapping("/verify")
+  public ResponseEntity<Void> verify(@RequestParam UUID token) {
+    return tokenRepository
+        .findByToken(token)
+        .map(
+            vt -> {
+              User user = vt.getUser();
+              user.setActive(true);
+              userService.update(user);
+              tokenRepository.delete(vt);
+              return ResponseEntity.ok().<Void>build();
+            })
+        .orElse(ResponseEntity.status(HttpStatus.BAD_REQUEST).build());
   }
 }

--- a/backend/src/main/java/com/example/scheduletracker/entity/User.java
+++ b/backend/src/main/java/com/example/scheduletracker/entity/User.java
@@ -30,6 +30,9 @@ public class User {
   @Column(name = "two_fa_enabled")
   private boolean twoFaEnabled;
 
+  @Column(nullable = false)
+  private boolean active;
+
   public User() {}
 
   public User(
@@ -38,13 +41,15 @@ public class User {
       String password,
       Role role,
       String twoFaSecret,
-      boolean twoFaEnabled) {
+      boolean twoFaEnabled,
+      boolean active) {
     this.id = id;
     this.username = username;
     this.password = password;
     this.role = role;
     this.twoFaSecret = twoFaSecret;
     this.twoFaEnabled = twoFaEnabled;
+    this.active = active;
   }
 
   public UUID getId() {
@@ -95,6 +100,14 @@ public class User {
     this.twoFaEnabled = twoFaEnabled;
   }
 
+  public boolean isActive() {
+    return active;
+  }
+
+  public void setActive(boolean active) {
+    this.active = active;
+  }
+
   public static Builder builder() {
     return new Builder();
   }
@@ -106,6 +119,7 @@ public class User {
     private Role role;
     private String twoFaSecret;
     private boolean twoFaEnabled;
+    private boolean active;
 
     public Builder id(UUID id) {
       this.id = id;
@@ -137,8 +151,13 @@ public class User {
       return this;
     }
 
+    public Builder active(boolean active) {
+      this.active = active;
+      return this;
+    }
+
     public User build() {
-      return new User(id, username, password, role, twoFaSecret, twoFaEnabled);
+      return new User(id, username, password, role, twoFaSecret, twoFaEnabled, active);
     }
   }
 

--- a/backend/src/main/java/com/example/scheduletracker/entity/VerificationToken.java
+++ b/backend/src/main/java/com/example/scheduletracker/entity/VerificationToken.java
@@ -1,0 +1,41 @@
+package com.example.scheduletracker.entity;
+
+import jakarta.persistence.*;
+import java.util.UUID;
+
+/** Token used for account verification. */
+@Entity
+@Table(name = "verification_token")
+public class VerificationToken {
+
+  @Id
+  @Column(columnDefinition = "uuid")
+  private UUID token;
+
+  @ManyToOne(optional = false)
+  @JoinColumn(name = "user_id")
+  private User user;
+
+  public VerificationToken() {}
+
+  public VerificationToken(UUID token, User user) {
+    this.token = token;
+    this.user = user;
+  }
+
+  public UUID getToken() {
+    return token;
+  }
+
+  public void setToken(UUID token) {
+    this.token = token;
+  }
+
+  public User getUser() {
+    return user;
+  }
+
+  public void setUser(User user) {
+    this.user = user;
+  }
+}

--- a/backend/src/main/java/com/example/scheduletracker/mapper/UserMapper.java
+++ b/backend/src/main/java/com/example/scheduletracker/mapper/UserMapper.java
@@ -11,5 +11,7 @@ public interface UserMapper {
 
   @Mapping(target = "password", ignore = true)
   @Mapping(target = "twoFaSecret", ignore = true)
+  @Mapping(target = "twoFaEnabled", ignore = true)
+  @Mapping(target = "active", ignore = true)
   User toEntity(UserDto dto);
 }

--- a/backend/src/main/java/com/example/scheduletracker/repository/VerificationTokenRepository.java
+++ b/backend/src/main/java/com/example/scheduletracker/repository/VerificationTokenRepository.java
@@ -1,0 +1,10 @@
+package com.example.scheduletracker.repository;
+
+import com.example.scheduletracker.entity.VerificationToken;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VerificationTokenRepository extends JpaRepository<VerificationToken, UUID> {
+  Optional<VerificationToken> findByToken(UUID token);
+}

--- a/backend/src/main/resources/db/migration/V7__verification_token.sql
+++ b/backend/src/main/resources/db/migration/V7__verification_token.sql
@@ -1,0 +1,4 @@
+CREATE TABLE verification_token (
+    token UUID PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id)
+);

--- a/backend/src/test/java/com/example/scheduletracker/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/example/scheduletracker/controller/AuthControllerTest.java
@@ -1,12 +1,15 @@
 package com.example.scheduletracker.controller;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.example.scheduletracker.config.jwt.JwtUtils;
 import com.example.scheduletracker.entity.User;
+import com.example.scheduletracker.entity.VerificationToken;
+import com.example.scheduletracker.repository.VerificationTokenRepository;
+import com.example.scheduletracker.service.NotificationService;
 import com.example.scheduletracker.service.UserService;
 import com.example.scheduletracker.service.security.TotpService;
 import org.junit.jupiter.api.Test;
@@ -27,6 +30,8 @@ class AuthControllerTest {
   @MockBean JwtUtils utils;
   @MockBean UserService userService;
   @MockBean TotpService totpService;
+  @MockBean NotificationService notificationService;
+  @MockBean VerificationTokenRepository tokenRepository;
 
   @Test
   void loginReturnsOk() throws Exception {
@@ -34,7 +39,8 @@ class AuthControllerTest {
     when(authManager.authenticate(any())).thenReturn(auth);
     when(userService.findByUsername("user"))
         .thenReturn(
-            java.util.Optional.of(new User(null, "user", null, User.Role.TEACHER, "s", true)));
+            java.util.Optional.of(
+                new User(null, "user", null, User.Role.TEACHER, "s", true, true)));
     when(totpService.verifyCode("s", "123456")).thenReturn(true);
     when(utils.generateToken(any(), any())).thenReturn("token");
 
@@ -51,7 +57,8 @@ class AuthControllerTest {
     when(authManager.authenticate(any())).thenReturn(auth);
     when(userService.findByUsername("user"))
         .thenReturn(
-            java.util.Optional.of(new User(null, "user", null, User.Role.TEACHER, "s", false)));
+            java.util.Optional.of(
+                new User(null, "user", null, User.Role.TEACHER, "s", false, true)));
     when(utils.generateToken(any(), any())).thenReturn("t");
 
     mvc.perform(
@@ -69,13 +76,24 @@ class AuthControllerTest {
     when(totpService.generateSecret()).thenReturn("secret");
     when(userService.save(any()))
         .thenReturn(
-            new User(java.util.UUID.randomUUID(), "new", "p", User.Role.STUDENT, "secret", false));
+            new User(
+                java.util.UUID.randomUUID(),
+                "new",
+                "p",
+                User.Role.STUDENT,
+                "secret",
+                false,
+                false));
+    when(tokenRepository.save(any())).thenReturn(null);
 
     mvc.perform(
             post("/api/auth/register")
                 .contentType("application/json")
                 .content("{\"username\":\"new\",\"password\":\"p\"}"))
         .andExpect(status().isCreated());
+
+    verify(notificationService)
+        .sendEmail(eq("new"), eq("Verify account"), startsWith("/api/auth/verify?token="));
   }
 
   @Test
@@ -94,5 +112,35 @@ class AuthControllerTest {
                 .contentType("application/json")
                 .content("{\"password\":\"p\"}"))
         .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void loginRejectsUnverifiedUser() throws Exception {
+    Authentication auth = new UsernamePasswordAuthenticationToken("user", "pass");
+    when(authManager.authenticate(any())).thenReturn(auth);
+    when(userService.findByUsername("user"))
+        .thenReturn(
+            java.util.Optional.of(
+                new User(null, "user", null, User.Role.STUDENT, null, false, false)));
+
+    mvc.perform(
+            post("/api/auth/login")
+                .contentType("application/json")
+                .content("{\"username\":\"u\",\"password\":\"p\",\"code\":\"000000\"}"))
+        .andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  void verifyActivatesUser() throws Exception {
+    java.util.UUID token = java.util.UUID.randomUUID();
+    User user = new User(null, "u", "p", User.Role.STUDENT, null, false, false);
+    when(tokenRepository.findByToken(token))
+        .thenReturn(java.util.Optional.of(new VerificationToken(token, user)));
+
+    mvc.perform(get("/api/auth/verify").param("token", token.toString()))
+        .andExpect(status().isOk());
+
+    verify(userService).update(argThat(u -> u.isActive()));
+    verify(tokenRepository).delete(any());
   }
 }

--- a/backend/src/test/java/com/example/scheduletracker/controller/SettingsControllerTest.java
+++ b/backend/src/test/java/com/example/scheduletracker/controller/SettingsControllerTest.java
@@ -32,7 +32,7 @@ class SettingsControllerTest {
   void getReturnsSettings() throws Exception {
     UUID id = UUID.randomUUID();
     when(userService.findByUsername("alice"))
-        .thenReturn(Optional.of(new User(id, "alice", "p", User.Role.TEACHER, null, false)));
+        .thenReturn(Optional.of(new User(id, "alice", "p", User.Role.TEACHER, null, false, true)));
     when(service.findByTeacherId(id)).thenReturn(Optional.of(new TeacherSettings(id, 5, "hi")));
 
     mvc.perform(get("/api/settings").principal(() -> "alice"))
@@ -45,7 +45,7 @@ class SettingsControllerTest {
   void putUpdatesSettings() throws Exception {
     UUID id = UUID.randomUUID();
     when(userService.findByUsername("bob"))
-        .thenReturn(Optional.of(new User(id, "bob", "p", User.Role.TEACHER, null, false)));
+        .thenReturn(Optional.of(new User(id, "bob", "p", User.Role.TEACHER, null, false, true)));
     TeacherSettings ts = new TeacherSettings(id, 10, "ok");
     when(service.save(ts)).thenReturn(ts);
 

--- a/backend/src/test/java/com/example/scheduletracker/controller/UserControllerTwoFaTest.java
+++ b/backend/src/test/java/com/example/scheduletracker/controller/UserControllerTwoFaTest.java
@@ -27,7 +27,7 @@ class UserControllerTwoFaTest {
 
   @Test
   void enableTwoFaReturnsSecret() throws Exception {
-    User user = new User(null, "alice", "p", User.Role.STUDENT, null, false);
+    User user = new User(null, "alice", "p", User.Role.STUDENT, null, false, true);
     when(svc.findByUsername("alice")).thenReturn(Optional.of(user));
     when(totpService.generateSecret()).thenReturn("sec");
     when(svc.update(any())).thenReturn(user);
@@ -41,7 +41,7 @@ class UserControllerTwoFaTest {
 
   @Test
   void disableTwoFaUpdatesUser() throws Exception {
-    User user = new User(null, "bob", "p", User.Role.STUDENT, "s", true);
+    User user = new User(null, "bob", "p", User.Role.STUDENT, "s", true, true);
     when(svc.findByUsername("bob")).thenReturn(Optional.of(user));
     when(svc.update(any())).thenReturn(user);
 

--- a/backend/src/test/java/com/example/scheduletracker/service/UserServiceImplTest.java
+++ b/backend/src/test/java/com/example/scheduletracker/service/UserServiceImplTest.java
@@ -29,7 +29,7 @@ class UserServiceImplTest {
   @Test
   void saveEncodesPassword() {
     when(repo.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
-    User u = new User(null, "alice", "secret", User.Role.STUDENT, null, false);
+    User u = new User(null, "alice", "secret", User.Role.STUDENT, null, false, true);
 
     User saved = service.save(u);
 

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Format Java code before committing
+DIR="$(git rev-parse --show-toplevel)"
+cd "$DIR/backend" && ./gradlew spotlessApply >/dev/null


### PR DESCRIPTION
## Summary
- add `VerificationToken` entity and repository
- mark new users inactive and send verification email
- implement `/api/auth/verify` endpoint
- block login for unverified accounts
- cover new flows with unit tests
- fix formatting and add pre-commit hook to auto-run Spotless

## Testing
- `./backend/gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6846d67b1a3c8326bfaec7ddd0fcfb29