### PR TITLE
Implement email notifications with JavaMailSender

### DIFF
--- a/backend/src/main/java/com/example/scheduletracker/ScheduleTrackerApplication.java
+++ b/backend/src/main/java/com/example/scheduletracker/ScheduleTrackerApplication.java
@@ -4,9 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableAsync
 @EnableAspectJAutoProxy
 public class ScheduleTrackerApplication {
   public static void main(String[] args) {

--- a/backend/src/main/java/com/example/scheduletracker/service/impl/LoggingNotificationService.java
+++ b/backend/src/main/java/com/example/scheduletracker/service/impl/LoggingNotificationService.java
@@ -1,17 +1,46 @@
 package com.example.scheduletracker.service.impl;
 
 import com.example.scheduletracker.service.NotificationService;
+import jakarta.mail.internet.MimeMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 @Service
 public class LoggingNotificationService implements NotificationService {
   private static final Logger log = LoggerFactory.getLogger(LoggingNotificationService.class);
 
+  private final JavaMailSender mailSender;
+  private final String from;
+
+  @Autowired
+  public LoggingNotificationService(JavaMailSender mailSender,
+      @Value("${app.mail.from:no-reply@example.com}") String from) {
+    this.mailSender = mailSender;
+    this.from = from;
+  }
+
+
+  @Async
   @Override
   public void sendEmail(String to, String subject, String body) {
-    log.info("Send email to {} subject {}", to, subject);
+    try {
+      MimeMessage message = mailSender.createMimeMessage();
+      MimeMessageHelper helper = new MimeMessageHelper(message, "UTF-8");
+      helper.setFrom(from);
+      helper.setTo(to);
+      helper.setSubject(subject);
+      helper.setText(body, true);
+      mailSender.send(message);
+      log.info("Sent email to {} subject {}", to, subject);
+    } catch (Exception e) {
+      log.error("Failed to send email", e);
+    }
   }
 
   @Override

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -3,6 +3,18 @@ spring:
     default: h2
   jpa:
     open-in-view: false
+  mail:
+    host: ${SMTP_HOST:localhost}
+    port: ${SMTP_PORT:25}
+    username: ${SMTP_USERNAME:}
+    password: ${SMTP_PASSWORD:}
+    properties:
+      mail.smtp.auth: ${SMTP_AUTH:false}
+      mail.smtp.starttls.enable: ${SMTP_STARTTLS:false}
+
+app:
+  mail:
+    from: ${MAIL_FROM:no-reply@example.com}
 
 telegram:
   bot-token: ${TELEGRAM_BOT_TOKEN:}

--- a/backend/src/test/java/com/example/scheduletracker/service/impl/LoggingNotificationServiceTest.java
+++ b/backend/src/test/java/com/example/scheduletracker/service/impl/LoggingNotificationServiceTest.java
@@ -1,0 +1,31 @@
+package com.example.scheduletracker.service.impl;
+
+import static org.mockito.Mockito.*;
+
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.mail.javamail.JavaMailSender;
+
+class LoggingNotificationServiceTest {
+
+  @Mock private JavaMailSender mailSender;
+  @Mock private MimeMessage message;
+
+  private LoggingNotificationService service;
+
+  @BeforeEach
+  void setup() {
+    MockitoAnnotations.openMocks(this);
+    when(mailSender.createMimeMessage()).thenReturn(message);
+    service = new LoggingNotificationService(mailSender, "from@example.com");
+  }
+
+  @Test
+  void sendEmailUsesMailSender() {
+    service.sendEmail("to@example.com", "sub", "body");
+    verify(mailSender).send(message);
+  }
+}


### PR DESCRIPTION
## Summary
- implement `LoggingNotificationService` to send emails via `JavaMailSender`
- configure SMTP properties in `application.yml`
- enable async processing in the application
- add unit test for the new service

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6846dd7c88a48326835a870c8d385c8c