### PR TITLE
Add user registration and verification pages

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,8 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from './auth';
 import { AuthGate } from './components/AuthGate';
 import { LoginPage } from './pages/LoginPage';
+import { RegisterPage } from './pages/RegisterPage';
+import { VerifyPage } from './pages/VerifyPage';
 import { DashboardPage } from './pages/DashboardPage';
 import { SettingsPage } from './pages/SettingsPage';
 import { TeacherCalendarPage } from './pages/TeacherCalendarPage';
@@ -19,6 +21,8 @@ function App() {
         <AuthProvider>
           <Routes>
           <Route path="/login" element={<LoginPage />} />
+          <Route path="/register" element={<RegisterPage />} />
+          <Route path="/verify" element={<VerifyPage />} />
           <Route
             path="/settings"
             element={

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,4 +1,5 @@
 import { useState, type FormEvent } from 'react';
+import { Link } from 'react-router-dom';
 import { useAuth } from '../auth';
 
 export const LoginPage = () => {
@@ -50,6 +51,11 @@ export const LoginPage = () => {
         <button type="submit" className="bg-blue-500 text-white px-2 py-1">
           Login
         </button>
+        <div>
+          <Link to="/register" className="text-blue-600 underline">
+            Register
+          </Link>
+        </div>
       </form>
     </div>
   );

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,0 +1,81 @@
+import { useState, type FormEvent } from 'react';
+import { Link } from 'react-router-dom';
+
+export const RegisterPage = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [secret, setSecret] = useState('');
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setMessage('');
+    if (!email || !password || !confirm) {
+      setError('All fields are required');
+      return;
+    }
+    if (password !== confirm) {
+      setError('Passwords do not match');
+      return;
+    }
+    const res = await fetch('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: email, password, role: 'STUDENT' }),
+    });
+    if (res.ok) {
+      const data: { secret: string } = await res.json();
+      setSecret(data.secret);
+      setMessage('Check your email to verify the account.');
+    } else {
+      setError('Registration failed');
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center h-screen">
+      <form onSubmit={handleSubmit} className="space-y-2 p-4 border rounded">
+        <input
+          className="border p-1 block w-full"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <input
+          type="password"
+          className="border p-1 block w-full"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <input
+          type="password"
+          className="border p-1 block w-full"
+          placeholder="Confirm Password"
+          value={confirm}
+          onChange={(e) => setConfirm(e.target.value)}
+        />
+        {error && <div className="text-red-600">{error}</div>}
+        {message && <div className="text-green-600">{message}</div>}
+        {secret && (
+          <div className="text-sm break-all border p-2 bg-gray-100 rounded">
+            <p>Your 2FA secret:</p>
+            <p className="font-mono">{secret}</p>
+            <p>Add it to your authenticator app.</p>
+          </div>
+        )}
+        <button type="submit" className="bg-blue-500 text-white px-2 py-1">
+          Register
+        </button>
+        <div>
+          <Link to="/login" className="text-blue-600 underline">
+            Back to login
+          </Link>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/frontend/src/pages/VerifyPage.tsx
+++ b/frontend/src/pages/VerifyPage.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+
+export const VerifyPage = () => {
+  const [searchParams] = useSearchParams();
+  const [status, setStatus] = useState<'pending' | 'success' | 'error'>('pending');
+
+  useEffect(() => {
+    const token = searchParams.get('token');
+    if (!token) {
+      setStatus('error');
+      return;
+    }
+    fetch(`/api/auth/verify?token=${token}`)
+      .then((r) => (r.ok ? setStatus('success') : setStatus('error')))
+      .catch(() => setStatus('error'));
+  }, [searchParams]);
+
+  if (status === 'pending') return <div className="p-4">Verifying...</div>;
+  if (status === 'success')
+    return (
+      <div className="p-4">
+        Account verified. You can now{' '}
+        <Link to="/login" className="text-blue-600 underline">
+          log in
+        </Link>
+        .
+      </div>
+    );
+  return <div className="p-4 text-red-600">Verification failed.</div>;
+};


### PR DESCRIPTION
## Summary
- create RegisterPage with form and 2FA instructions
- create VerifyPage for `/verify` links
- link RegisterPage from LoginPage
- register new routes in `App`

## Testing
- `npm install`
- `npm run lint:fix`
- `npm run lint`
- `./gradlew test` *(failed: Calculating task graph as no cached configuration is available for tasks: test)*

------
https://chatgpt.com/codex/tasks/task_e_6846eb0494748326873e6652f7fd2059