### PR TITLE
Add 2FA toggle on settings page

### DIFF
--- a/backend/src/main/java/com/example/scheduletracker/dto/UserDto.java
+++ b/backend/src/main/java/com/example/scheduletracker/dto/UserDto.java
@@ -3,4 +3,4 @@ package com.example.scheduletracker.dto;
 /** Lightweight representation of a user */
 import java.util.UUID;
 
-public record UserDto(UUID id, String username, String role) {}
+public record UserDto(UUID id, String username, String role, boolean twoFaEnabled) {}

--- a/frontend/src/auth.tsx
+++ b/frontend/src/auth.tsx
@@ -5,6 +5,7 @@ export interface UserInfo {
   id: string;
   username: string;
   role: string;
+  twoFaEnabled?: boolean;
 }
 
 export interface AuthContextValue {
@@ -12,6 +13,7 @@ export interface AuthContextValue {
   user: UserInfo | null;
   login: (t: string) => void;
   logout: () => void;
+  setUser: (u: UserInfo) => void;
 }
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
@@ -46,7 +48,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       .catch(() => setUser(null));
   }, [token, navigate]);
 
-  const value: AuthContextValue = { token, user, login, logout };
+  const value: AuthContextValue = { token, user, login, logout, setUser };
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };
 

--- a/frontend/src/components/TwoFaToggle.tsx
+++ b/frontend/src/components/TwoFaToggle.tsx
@@ -1,0 +1,65 @@
+import { useAuth } from '../auth';
+import { useEffect, useState } from 'react';
+
+export const TwoFaToggle = () => {
+  const { token, user, setUser } = useAuth();
+  const [enabled, setEnabled] = useState(false);
+  const [secret, setSecret] = useState<string | null>(null);
+
+  useEffect(() => {
+    setEnabled(user?.twoFaEnabled ?? false);
+  }, [user]);
+
+  const toggle = async () => {
+    if (!token) return;
+    if (enabled) {
+      await fetch('/api/users/me/2fa/disable', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      setEnabled(false);
+      setSecret(null);
+      if (user) setUser({ ...user, twoFaEnabled: false });
+    } else {
+      const res = await fetch('/api/users/me/2fa/enable', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      if (res.ok) {
+        const data: { secret: string } = await res.json();
+        setSecret(data.secret);
+        setEnabled(true);
+        if (user) setUser({ ...user, twoFaEnabled: true });
+      }
+    }
+  };
+
+  const qrUrl = secret
+    ? `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(
+        `otpauth://totp/ScheduleTracker:${user?.username}?secret=${secret}&issuer=ScheduleTracker`,
+      )}`
+    : null;
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center space-x-2">
+        <span>Two-factor authentication:</span>
+        <span className={enabled ? 'text-green-600' : 'text-red-600'}>
+          {enabled ? 'Enabled' : 'Disabled'}
+        </span>
+        <button className="border px-2 py-1" onClick={toggle}>
+          {enabled ? 'Disable' : 'Enable'}
+        </button>
+      </div>
+      {secret && (
+        <div className="space-y-2">
+          <div className="text-sm break-all border p-2 bg-gray-100 rounded">
+            Add this secret to your authenticator app:{' '}
+            <span className="font-mono">{secret}</span>
+          </div>
+          {qrUrl && <img src={qrUrl} alt="QR Code" className="mx-auto" />}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Sidebar } from '../components/Sidebar';
+import { TwoFaToggle } from '../components/TwoFaToggle';
 
 export const SettingsPage = () => {
   const [buffer, setBuffer] = useState(0);
@@ -44,6 +45,7 @@ export const SettingsPage = () => {
             onChange={(e) => setTemplate(e.target.value)}
           />
         </div>
+        <TwoFaToggle />
         <button className="border px-2" onClick={save}>
           Save
         </button>


### PR DESCRIPTION
## Summary
- add `twoFaEnabled` field to `UserDto`
- expose `setUser` in auth context and store 2FA status
- implement `TwoFaToggle` component and show it on settings page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `./gradlew test` *(fails: Gradle daemon startup issues)*

------
https://chatgpt.com/codex/tasks/task_e_6846f02e10648326a7cfe0214a5a1471