### PR TITLE
Add apiFetch helper and refactor fetch calls

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,16 @@
+import { useAuth } from './auth';
+import { useCallback } from 'react';
+
+export function useApiFetch() {
+  const { token } = useAuth();
+  return useCallback(
+    (path: string, options: RequestInit = {}) => {
+      const headers = new Headers(options.headers || {});
+      if (token) {
+        headers.set('Authorization', `Bearer ${token}`);
+      }
+      return fetch(path, { ...options, headers });
+    },
+    [token]
+  );
+}

--- a/frontend/src/components/ManagerCalendar.tsx
+++ b/frontend/src/components/ManagerCalendar.tsx
@@ -3,6 +3,7 @@ import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import timeGridPlugin from '@fullcalendar/timegrid';
 import { type EventInput } from '@fullcalendar/core';
+import { useApiFetch } from '../api';
 
 interface Teacher {
   id: string;
@@ -21,19 +22,20 @@ export const ManagerCalendar = () => {
   const [teacherId, setTeacherId] = useState<string | null>(null);
   const [events, setEvents] = useState<EventInput[]>([]);
   const [modalLesson, setModalLesson] = useState<Lesson | null>(null);
+  const apiFetch = useApiFetch();
 
   useEffect(() => {
-    fetch('/api/teachers')
+    apiFetch('/api/teachers')
       .then((r) => r.json())
       .then((data: Teacher[]) => {
         setTeachers(data);
         if (data.length > 0) setTeacherId(String(data[0].id));
       });
-  }, []);
+  }, [apiFetch]);
 
   useEffect(() => {
     if (!teacherId) return;
-    fetch(`/api/lessons?teacherId=${teacherId}`)
+    apiFetch(`/api/lessons?teacherId=${teacherId}`)
       .then((r) => r.json())
       .then((data: Lesson[]) =>
         setEvents(
@@ -46,7 +48,7 @@ export const ManagerCalendar = () => {
           }))
         )
       );
-  }, [teacherId]);
+  }, [teacherId, apiFetch]);
 
   return (
     <div>

--- a/frontend/src/components/StudentCombobox.tsx
+++ b/frontend/src/components/StudentCombobox.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useApiFetch } from '../api';
 
 export interface Student {
   id: string;
@@ -13,12 +14,13 @@ interface Props {
 
 export const StudentCombobox = ({ value, onChange }: Props) => {
   const [students, setStudents] = useState<Student[]>([]);
+  const apiFetch = useApiFetch();
 
   useEffect(() => {
-    fetch('/api/students')
+    apiFetch('/api/students')
       .then((r) => r.json())
       .then((data: Student[]) => setStudents(data));
-  }, []);
+  }, [apiFetch]);
 
   return (
     <select

--- a/frontend/src/components/StudentDialog.tsx
+++ b/frontend/src/components/StudentDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { Student } from './StudentCombobox';
+import { useApiFetch } from '../api';
 
 interface Props {
   student?: Student;
@@ -10,6 +11,7 @@ interface Props {
 export const StudentDialog = ({ student, onClose, onSaved }: Props) => {
   const [name, setName] = useState(student?.name ?? '');
   const [email, setEmail] = useState(student?.email ?? '');
+  const apiFetch = useApiFetch();
 
   useEffect(() => {
     setName(student?.name ?? '');
@@ -18,7 +20,7 @@ export const StudentDialog = ({ student, onClose, onSaved }: Props) => {
 
   const save = () => {
     const body = JSON.stringify({ id: student?.id, name, email });
-    fetch(`/api/students${student ? '/' + student.id : ''}`, {
+    apiFetch(`/api/students${student ? '/' + student.id : ''}`, {
       method: student ? 'PUT' : 'POST',
       headers: { 'Content-Type': 'application/json' },
       body,

--- a/frontend/src/components/TeacherCalendar.tsx
+++ b/frontend/src/components/TeacherCalendar.tsx
@@ -4,6 +4,7 @@ import dayGridPlugin from '@fullcalendar/daygrid';
 import timeGridPlugin from '@fullcalendar/timegrid';
 import { type EventInput } from '@fullcalendar/core';
 import { useAuth } from '../auth';
+import { useApiFetch } from '../api';
 
 interface Lesson {
   id: string;
@@ -14,6 +15,7 @@ interface Lesson {
 
 export const TeacherCalendar = () => {
   const { user, token } = useAuth();
+  const apiFetch = useApiFetch();
   const [events, setEvents] = useState<EventInput[]>([]);
   const [error, setError] = useState<string | null>(null);
 
@@ -23,9 +25,7 @@ export const TeacherCalendar = () => {
       setError('No teacher account associated with user');
       return;
     }
-    fetch(`/api/teacher/lessons?teacherId=${user.id}`, {
-      headers: { Authorization: `Bearer ${token}` },
-    })
+    apiFetch(`/api/teacher/lessons?teacherId=${user.id}`)
       .then((r) => (r.ok ? r.json() : Promise.reject()))
       .then((data: Lesson[]) => {
         setEvents(
@@ -38,7 +38,7 @@ export const TeacherCalendar = () => {
         );
       })
       .catch(() => setError('Failed to load lessons'));
-  }, [user, token]);
+  }, [user, token, apiFetch]);
 
   if (!user) return <div>Loading...</div>;
   if (error) return <div className="text-red-600">{error}</div>;

--- a/frontend/src/components/TemplateDialog.tsx
+++ b/frontend/src/components/TemplateDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useApiFetch } from '../api';
 
 export interface Template {
   id?: string;
@@ -19,6 +20,7 @@ export const TemplateDialog = ({ template, onClose, onSaved }: Props) => {
   const [lang, setLang] = useState(template?.lang ?? 'en');
   const [subject, setSubject] = useState(template?.subject ?? '');
   const [bodyHtml, setBodyHtml] = useState(template?.bodyHtml ?? '');
+  const apiFetch = useApiFetch();
 
   useEffect(() => {
     setCode(template?.code ?? '');
@@ -29,7 +31,7 @@ export const TemplateDialog = ({ template, onClose, onSaved }: Props) => {
 
   const save = () => {
     const body = JSON.stringify({ id: template?.id, code, lang, subject, bodyHtml });
-    fetch(`/api/templates${template ? '/' + template.id : ''}`, {
+    apiFetch(`/api/templates${template ? '/' + template.id : ''}`, {
       method: template ? 'PUT' : 'POST',
       headers: { 'Content-Type': 'application/json' },
       body,

--- a/frontend/src/components/TwoFaToggle.tsx
+++ b/frontend/src/components/TwoFaToggle.tsx
@@ -1,10 +1,12 @@
 import { useAuth } from '../auth';
 import { useEffect, useState } from 'react';
+import { useApiFetch } from '../api';
 
 export const TwoFaToggle = () => {
   const { token, user, setUser } = useAuth();
   const [enabled, setEnabled] = useState(false);
   const [secret, setSecret] = useState<string | null>(null);
+  const apiFetch = useApiFetch();
 
   useEffect(() => {
     setEnabled(user?.twoFaEnabled ?? false);
@@ -13,17 +15,15 @@ export const TwoFaToggle = () => {
   const toggle = async () => {
     if (!token) return;
     if (enabled) {
-      await fetch('/api/users/me/2fa/disable', {
+      await apiFetch('/api/users/me/2fa/disable', {
         method: 'POST',
-        headers: { Authorization: `Bearer ${token}` },
       });
       setEnabled(false);
       setSecret(null);
       if (user) setUser({ ...user, twoFaEnabled: false });
     } else {
-      const res = await fetch('/api/users/me/2fa/enable', {
+      const res = await apiFetch('/api/users/me/2fa/enable', {
         method: 'POST',
-        headers: { Authorization: `Bearer ${token}` },
       });
       if (res.ok) {
         const data: { secret: string } = await res.json();

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { Line, LineChart, Tooltip, XAxis, YAxis } from 'recharts';
 import { Sidebar } from '../components/Sidebar';
+import { useApiFetch } from '../api';
 
 interface Point {
   date: string;
@@ -8,10 +9,11 @@ interface Point {
 }
 
 export const DashboardPage = () => {
+  const apiFetch = useApiFetch();
   const { data } = useQuery<Point[]>({
     queryKey: ['analytics'],
     queryFn: () =>
-      fetch('/api/analytics')
+      apiFetch('/api/analytics')
         .then((r) => r.json())
         .then((d) => d as Point[]),
   });

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,9 +1,11 @@
 import { useState, type FormEvent } from 'react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '../auth';
+import { useApiFetch } from '../api';
 
 export const LoginPage = () => {
   const { login } = useAuth();
+  const apiFetch = useApiFetch();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [code, setCode] = useState('');
@@ -12,7 +14,7 @@ export const LoginPage = () => {
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setError('');
-    const res = await fetch('/api/auth/login', {
+    const res = await apiFetch('/api/auth/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password, code }),

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,5 +1,6 @@
 import { useState, type FormEvent } from 'react';
 import { Link } from 'react-router-dom';
+import { useApiFetch } from '../api';
 
 export const RegisterPage = () => {
   const [email, setEmail] = useState('');
@@ -8,6 +9,7 @@ export const RegisterPage = () => {
   const [secret, setSecret] = useState('');
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
+  const apiFetch = useApiFetch();
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -21,7 +23,7 @@ export const RegisterPage = () => {
       setError('Passwords do not match');
       return;
     }
-    const res = await fetch('/api/auth/register', {
+    const res = await apiFetch('/api/auth/register', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username: email, password, role: 'STUDENT' }),

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,23 +1,25 @@
 import { useEffect, useState } from 'react';
 import { Sidebar } from '../components/Sidebar';
 import { TwoFaToggle } from '../components/TwoFaToggle';
+import { useApiFetch } from '../api';
 
 export const SettingsPage = () => {
   const [buffer, setBuffer] = useState(0);
   const [template, setTemplate] = useState('');
+  const apiFetch = useApiFetch();
 
   useEffect(() => {
-    fetch('/api/settings')
+    apiFetch('/api/settings')
       .then((r) => r.json())
       .then((d) => {
         setBuffer(d.bufferMin ?? 0);
         setTemplate(d.template ?? '');
       })
       .catch(() => {});
-  }, []);
+  }, [apiFetch]);
 
   const save = () => {
-    fetch('/api/settings', {
+    apiFetch('/api/settings', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ bufferMin: buffer, template }),

--- a/frontend/src/pages/StudentsPage.tsx
+++ b/frontend/src/pages/StudentsPage.tsx
@@ -2,20 +2,22 @@ import { useEffect, useState } from 'react';
 import { Sidebar } from '../components/Sidebar';
 import type { Student } from '../components/StudentCombobox';
 import { StudentDialog } from '../components/StudentDialog';
+import { useApiFetch } from '../api';
 
 export const StudentsPage = () => {
   const [students, setStudents] = useState<Student[]>([]);
   const [search, setSearch] = useState('');
   const [editing, setEditing] = useState<Student | null>(null);
   const [creating, setCreating] = useState(false);
+  const apiFetch = useApiFetch();
 
   const load = () => {
-    fetch('/api/students')
+    apiFetch('/api/students')
       .then((r) => r.json())
       .then((data: Student[]) => setStudents(data));
   };
 
-  useEffect(load, []);
+  useEffect(load, [apiFetch]);
 
   const filtered = students.filter(
     (s) =>
@@ -24,7 +26,7 @@ export const StudentsPage = () => {
   );
 
   const remove = (id: string) => {
-    fetch(`/api/students/${id}`, { method: 'DELETE' }).then(load);
+    apiFetch(`/api/students/${id}`, { method: 'DELETE' }).then(load);
   };
 
   return (

--- a/frontend/src/pages/TemplatesPage.tsx
+++ b/frontend/src/pages/TemplatesPage.tsx
@@ -2,22 +2,24 @@ import { useEffect, useState } from 'react';
 import { Sidebar } from '../components/Sidebar';
 import { TemplateDialog } from '../components/TemplateDialog';
 import type { Template } from '../components/TemplateDialog';
+import { useApiFetch } from '../api';
 
 export const TemplatesPage = () => {
   const [templates, setTemplates] = useState<Template[]>([]);
   const [editing, setEditing] = useState<Template | null>(null);
   const [creating, setCreating] = useState(false);
+  const apiFetch = useApiFetch();
 
   const load = () => {
-    fetch('/api/templates')
+    apiFetch('/api/templates')
       .then((r) => r.json())
       .then((data: Template[]) => setTemplates(data));
   };
 
-  useEffect(load, []);
+  useEffect(load, [apiFetch]);
 
   const remove = (id: string) => {
-    fetch(`/api/templates/${id}`, { method: 'DELETE' }).then(load);
+    apiFetch(`/api/templates/${id}`, { method: 'DELETE' }).then(load);
   };
 
   return (

--- a/frontend/src/pages/VerifyPage.tsx
+++ b/frontend/src/pages/VerifyPage.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
+import { useApiFetch } from '../api';
 
 export const VerifyPage = () => {
   const [searchParams] = useSearchParams();
   const [status, setStatus] = useState<'pending' | 'success' | 'error'>('pending');
+  const apiFetch = useApiFetch();
 
   useEffect(() => {
     const token = searchParams.get('token');
@@ -11,10 +13,10 @@ export const VerifyPage = () => {
       setStatus('error');
       return;
     }
-    fetch(`/api/auth/verify?token=${token}`)
+    apiFetch(`/api/auth/verify?token=${token}`)
       .then((r) => (r.ok ? setStatus('success') : setStatus('error')))
       .catch(() => setStatus('error'));
-  }, [searchParams]);
+  }, [searchParams, apiFetch]);
 
   if (status === 'pending') return <div className="p-4">Verifying...</div>;
   if (status === 'success')


### PR DESCRIPTION
## Summary
- add `useApiFetch` helper to inject auth token into requests
- refactor pages and components to use the helper
- ensure frontend build succeeds

## Testing
- `npm --prefix frontend install`
- `npm --prefix frontend run build`

------
https://chatgpt.com/codex/tasks/task_e_684726b629288326bbbd212499851635