### PR TITLE
Refactor routing layout

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from './auth';
 import { AuthGate } from './components/AuthGate';
+import { Layout } from './components/Layout';
 import { LoginPage } from './pages/LoginPage';
 import { RegisterPage } from './pages/RegisterPage';
 import { VerifyPage } from './pages/VerifyPage';
@@ -24,53 +25,20 @@ function App() {
           <Route path="/register" element={<RegisterPage />} />
           <Route path="/verify" element={<VerifyPage />} />
           <Route
-            path="/settings"
-            element={
-              <AuthGate>
-                <SettingsPage />
-              </AuthGate>
-            }
-          />
-          <Route
-            path="/calendar"
-            element={
-              <AuthGate>
-                <TeacherCalendarPage />
-              </AuthGate>
-            }
-          />
-          <Route
-            path="/manager"
-            element={
-              <AuthGate>
-                <ManagerCalendarPage />
-              </AuthGate>
-            }
-          />
-          <Route
-            path="/students"
-            element={
-              <AuthGate>
-                <StudentsPage />
-              </AuthGate>
-            }
-          />
-          <Route
-            path="/templates"
-            element={
-              <AuthGate>
-                <TemplatesPage />
-              </AuthGate>
-            }
-          />
-          <Route
             path="/"
             element={
               <AuthGate>
-                <DashboardPage />
+                <Layout />
               </AuthGate>
             }
-          />
+          >
+            <Route index element={<DashboardPage />} />
+            <Route path="calendar" element={<TeacherCalendarPage />} />
+            <Route path="manager" element={<ManagerCalendarPage />} />
+            <Route path="students" element={<StudentsPage />} />
+            <Route path="templates" element={<TemplatesPage />} />
+            <Route path="settings" element={<SettingsPage />} />
+          </Route>
         </Routes>
         </AuthProvider>
       </QueryClientProvider>

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from 'react-router-dom';
+import { Sidebar } from './Sidebar';
+
+export const Layout = () => (
+  <div className="flex">
+    <Sidebar />
+    <div className="p-4 flex-1">
+      <Outlet />
+    </div>
+  </div>
+);

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,6 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
 import { Line, LineChart, Tooltip, XAxis, YAxis } from 'recharts';
-import { Sidebar } from '../components/Sidebar';
 import { useApiFetch } from '../api';
 
 interface Point {
@@ -19,20 +18,17 @@ export const DashboardPage = () => {
   });
 
   return (
-    <div className="flex">
-      <Sidebar />
-      <div className="p-4 flex-1">
-        {data ? (
-          <LineChart width={600} height={300} data={data}>
-            <XAxis dataKey="date" />
-            <YAxis />
-            <Tooltip />
-            <Line type="monotone" dataKey="value" stroke="#3b82f6" />
-          </LineChart>
-        ) : (
-          'Loading...'
-        )}
-      </div>
+    <div>
+      {data ? (
+        <LineChart width={600} height={300} data={data}>
+          <XAxis dataKey="date" />
+          <YAxis />
+          <Tooltip />
+          <Line type="monotone" dataKey="value" stroke="#3b82f6" />
+        </LineChart>
+      ) : (
+        'Loading...'
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/ManagerCalendarPage.tsx
+++ b/frontend/src/pages/ManagerCalendarPage.tsx
@@ -1,11 +1,3 @@
-import { Sidebar } from '../components/Sidebar';
 import { ManagerCalendar } from '../components/ManagerCalendar';
 
-export const ManagerCalendarPage = () => (
-  <div className="flex">
-    <Sidebar />
-    <div className="flex-1 p-4">
-      <ManagerCalendar />
-    </div>
-  </div>
-);
+export const ManagerCalendarPage = () => <ManagerCalendar />;

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { Sidebar } from '../components/Sidebar';
 import { TwoFaToggle } from '../components/TwoFaToggle';
 import { useApiFetch } from '../api';
 
@@ -27,31 +26,28 @@ export const SettingsPage = () => {
   };
 
   return (
-    <div className="flex">
-      <Sidebar />
-      <div className="p-4 flex-1 space-y-4">
-        <div>
-          <label className="block">Teacher buffer (min)</label>
-          <input
-            type="number"
-            className="border p-1"
-            value={buffer}
-            onChange={(e) => setBuffer(Number(e.target.value))}
-          />
-        </div>
-        <div>
-          <label className="block">Notification template</label>
-          <textarea
-            className="border p-1 w-full h-32"
-            value={template}
-            onChange={(e) => setTemplate(e.target.value)}
-          />
-        </div>
-        <TwoFaToggle />
-        <button className="border px-2" onClick={save}>
-          Save
-        </button>
+    <div className="space-y-4">
+      <div>
+        <label className="block">Teacher buffer (min)</label>
+        <input
+          type="number"
+          className="border p-1"
+          value={buffer}
+          onChange={(e) => setBuffer(Number(e.target.value))}
+        />
       </div>
+      <div>
+        <label className="block">Notification template</label>
+        <textarea
+          className="border p-1 w-full h-32"
+          value={template}
+          onChange={(e) => setTemplate(e.target.value)}
+        />
+      </div>
+      <TwoFaToggle />
+      <button className="border px-2" onClick={save}>
+        Save
+      </button>
     </div>
   );
 };

--- a/frontend/src/pages/StudentsPage.tsx
+++ b/frontend/src/pages/StudentsPage.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { Sidebar } from '../components/Sidebar';
 import type { Student } from '../components/StudentCombobox';
 import { StudentDialog } from '../components/StudentDialog';
 import { useApiFetch } from '../api';
@@ -30,9 +29,7 @@ export const StudentsPage = () => {
   };
 
   return (
-    <div className="flex">
-      <Sidebar />
-      <div className="flex-1 p-4">
+    <div>
         <div className="flex justify-between mb-2">
           <input
             className="border p-1 flex-1 mr-2"
@@ -91,7 +88,6 @@ export const StudentsPage = () => {
             }}
           />
         )}
-      </div>
     </div>
   );
 };

--- a/frontend/src/pages/TeacherCalendarPage.tsx
+++ b/frontend/src/pages/TeacherCalendarPage.tsx
@@ -1,11 +1,3 @@
 import { TeacherCalendar } from '../components/TeacherCalendar';
-import { Sidebar } from '../components/Sidebar';
 
-export const TeacherCalendarPage = () => (
-  <div className="flex">
-    <Sidebar />
-    <div className="flex-1 p-4">
-      <TeacherCalendar />
-    </div>
-  </div>
-);
+export const TeacherCalendarPage = () => <TeacherCalendar />;

--- a/frontend/src/pages/TemplatesPage.tsx
+++ b/frontend/src/pages/TemplatesPage.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { Sidebar } from '../components/Sidebar';
 import { TemplateDialog } from '../components/TemplateDialog';
 import type { Template } from '../components/TemplateDialog';
 import { useApiFetch } from '../api';
@@ -23,9 +22,8 @@ export const TemplatesPage = () => {
   };
 
   return (
-    <div className="flex">
-      <Sidebar />
-      <div className="flex-1 p-4">
+    <div>
+      
         <div className="mb-2 text-right">
           <button className="border px-2" onClick={() => setCreating(true)}>
             New
@@ -77,7 +75,6 @@ export const TemplatesPage = () => {
             }}
           />
         )}
-      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add a shared `Layout` component with `Sidebar` and `Outlet`
- nest all authenticated routes under the layout
- remove per-page sidebar wrappers

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68472b1b3ee083268ff7aaed8c0b6e5a