### PR TITLE
Add NotFound page and error boundary

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -18,3 +18,9 @@ Create a `.env` file from `.env.example` to override `VITE_API_URL` when buildin
 ## Production build
 
 Run `npm run build` to generate static files in the `dist/` directory. These files can be served by NGINX or any static web server.
+
+## Error boundary
+
+Unexpected rendering errors are caught by a simple `<ErrorBoundary>` component.
+`App` wraps all routes in this boundary by default. You can also wrap
+individual parts of the UI with `<ErrorBoundary>` when needed.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from './auth';
 import { AuthGate } from './components/AuthGate';
 import { Layout } from './components/Layout';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import { LoginPage } from './pages/LoginPage';
 import { RegisterPage } from './pages/RegisterPage';
 import { VerifyPage } from './pages/VerifyPage';
@@ -12,15 +13,17 @@ import { TeacherCalendarPage } from './pages/TeacherCalendarPage';
 import { ManagerCalendarPage } from './pages/ManagerCalendarPage';
 import { StudentsPage } from './pages/StudentsPage';
 import { TemplatesPage } from './pages/TemplatesPage';
+import { NotFoundPage } from './pages/NotFoundPage';
 
 const queryClient = new QueryClient();
 
 function App() {
   return (
-    <BrowserRouter>
-      <QueryClientProvider client={queryClient}>
-        <AuthProvider>
-          <Routes>
+    <ErrorBoundary>
+      <BrowserRouter>
+        <QueryClientProvider client={queryClient}>
+          <AuthProvider>
+            <Routes>
           <Route path="/login" element={<LoginPage />} />
           <Route path="/register" element={<RegisterPage />} />
           <Route path="/verify" element={<VerifyPage />} />
@@ -39,10 +42,12 @@ function App() {
             <Route path="templates" element={<TemplatesPage />} />
             <Route path="settings" element={<SettingsPage />} />
           </Route>
+          <Route path="*" element={<NotFoundPage />} />
         </Routes>
-        </AuthProvider>
-      </QueryClientProvider>
-    </BrowserRouter>
+          </AuthProvider>
+        </QueryClientProvider>
+      </BrowserRouter>
+    </ErrorBoundary>
   );
 }
 

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,32 @@
+import { Component, type ReactNode, type ErrorInfo } from 'react';
+
+interface State {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<{ children: ReactNode }, State> {
+  constructor(props: { children: ReactNode }) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('Unexpected error:', error, info);
+  }
+
+  override render() {
+    if (this.state.error) {
+      return (
+        <div className="p-4 text-red-600">
+          <h1 className="text-lg font-bold mb-2">Something went wrong</h1>
+          <pre className="whitespace-pre-wrap">{this.state.error.message}</pre>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export const NotFoundPage = () => (
+  <div className="flex items-center justify-center h-full text-xl">
+    Page not found
+  </div>
+);


### PR DESCRIPTION
## Summary
- add `NotFoundPage` for unknown routes
- introduce a simple `ErrorBoundary` component and wrap routes with it
- document the error boundary in the frontend README

## Testing
- `npm run lint`
- `./backend/gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68473c210e508326b39c1c318a7bfbf4