### PR TITLE
Fix Deploy script for missing infra dir

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -183,9 +183,11 @@ jobs:
         # port:     ${{ secrets.VPS_PORT }}
         envs: DEPLOY_DIR
         script: |
-          cd "$HOME/$DEPLOY_DIR/infra"
-          if [ ! -f .env ]; then
-            cp .env.example .env
+          if [ -d "$HOME/$DEPLOY_DIR/infra" ]; then
+            cd "$HOME/$DEPLOY_DIR/infra"
+            if [ ! -f .env ] && [ -f .env.example ]; then
+              cp .env.example .env
+            fi
           fi
 
 


### PR DESCRIPTION
## Summary
- allow `AuthProvider.setUser` to accept `null`
- fetch user info via `apiFetch`
- guard `.env` prep step when `infra` folder is missing

## Testing
- `npm ci`
- `cd frontend && npm ci`
- `npm run lint`
- `npm run lint:fix`
- `npm run build`
- `./gradlew test` *(fails: Calculating task graph, process interrupted)*


------
https://chatgpt.com/codex/tasks/task_e_6847495396208326a551c625bf77f148