### PR TITLE
Improve JWT_SECRET docs

### DIFF
--- a/infra/.env.example
+++ b/infra/.env.example
@@ -1,6 +1,11 @@
+# Example environment configuration for docker compose.
+# Copy this file to `.env` and edit as needed.
+# IMPORTANT: replace JWT_SECRET with a strong random value before deployment.
+# Example: openssl rand -hex 32
 SPRING_PROFILES_ACTIVE=postgres
 DB_HOST=db
 DB_PORT=5432
+# Replace this value with a strong random string before deploying
 JWT_SECRET=0123456789abcdef0123456789abcdef
 SMTP_HOST=localhost
 SMTP_PORT=25


### PR DESCRIPTION
## Summary
- add instructions in infra/.env.example about using a strong JWT_SECRET

## Testing
- `./backend/gradlew spotlessApply test`
- `npm ci`
- `npm run lint`
- `npm run lint:fix`


------
https://chatgpt.com/codex/tasks/task_e_6847651b6b08832682ae28aba2833e77