### PR TITLE
Remove temporary TLS cert generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,10 +126,11 @@ jobs:
       working-directory: backend
 
 
-    - name: Generate test TLS certificate
+    - name: Write TLS certificate
       run: |
         mkdir -p infra/nginx/certs
-        openssl req -x509 -newkey rsa:2048 -nodes -keyout infra/nginx/certs/server.key -out infra/nginx/certs/server.crt -days 1 -subj "/CN=localhost"
+        echo "${{ secrets.TLS_CERT }}" > infra/nginx/certs/server.crt
+        echo "${{ secrets.TLS_KEY }}"  > infra/nginx/certs/server.key
 
     # Render environment-specific nginx.conf
     - name: Render NGINX config

--- a/README.md
+++ b/README.md
@@ -86,16 +86,9 @@
    Файл автоматически читается `docker compose` из `infra/.env`. Если переменная
    не задана, `docker compose` завершится ошибкой `JWT_SECRET: set JWT_SECRET in .env`.
    Файл добавлен в `.gitignore` и хранится локально.
-2. Создайте сертификат для Nginx. Выполните команду из корня репозитория,
-   чтобы итоговые файлы оказались в каталоге `infra/nginx/certs`:
-
-   ```bash
-   mkdir -p infra/nginx/certs && cd <repo-root>
-   openssl req -x509 -newkey rsa:2048 -nodes \
-     -keyout infra/nginx/certs/server.key \
-     -out infra/nginx/certs/server.crt \
-     -days 365 -subj "/CN=localhost"
-   ```
+2. Поместите в каталог `infra/nginx/certs` действующий сертификат и ключ для
+   Nginx (`server.crt` и `server.key`). В CI/CD файлы можно создавать из
+   секретов `TLS_CERT` и `TLS_KEY`.
 3. Соберите и запустите контейнеры через Makefile. Он использует
    `infra/docker-compose.yml`:
 

--- a/infra/nginx/certs/README.md
+++ b/infra/nginx/certs/README.md
@@ -1,6 +1,9 @@
 This directory should contain `server.crt` and `server.key` for HTTPS termination.
-Use a trusted certificate in production or generate a self-signed pair for local testing:
+Provide the real certificate and key in production. For local testing you may
+generate a self-signed pair, for example:
 
 ```bash
-openssl req -x509 -newkey rsa:2048 -nodes -keyout server.key -out server.crt -days 365 -subj "/CN=localhost"
+openssl req -x509 -newkey rsa:2048 -nodes \
+  -keyout server.key -out server.crt \
+  -days 365 -subj "/CN=localhost"
 ```


### PR DESCRIPTION
## Summary
- instruct to supply production TLS certificates instead of generating temporary ones
- reference `TLS_CERT` and `TLS_KEY` secrets in CI workflow

## Testing
- `./gradlew test --dry-run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68476505582c8326b85788012c424c59