### PR TITLE
Handle auth failures in useApiFetch

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -2,17 +2,21 @@ import { useAuth } from './auth';
 import { useCallback } from 'react';
 
 export function useApiFetch() {
-  const { token } = useAuth();
+  const { token, logout } = useAuth();
   return useCallback(
-    (path: string, options: RequestInit = {}) => {
+    async (path: string, options: RequestInit = {}) => {
       const headers = new Headers(options.headers || {});
       if (token) {
         headers.set('Authorization', `Bearer ${token}`);
       }
       const base = (import.meta.env.VITE_API_URL || '/').replace(/\/$/, '');
       const url = `${base}${path}`;
-      return fetch(url, { ...options, headers });
+      const res = await fetch(url, { ...options, headers });
+      if (res.status === 401 || res.status === 403) {
+        logout();
+      }
+      return res;
     },
-    [token]
+    [token, logout]
   );
 }


### PR DESCRIPTION
## Summary
- detect 401/403 responses inside `useApiFetch`
- logout and redirect to login when unauthorized

## Testing
- `./gradlew test --no-daemon` *(fails: Calculating task graph...)*

------
https://chatgpt.com/codex/tasks/task_e_684768a65614832689e0f6b72628413f