### PR TITLE
Add Let's Encrypt docs and nginx webroot support

### DIFF
--- a/docs/LETS_ENCRYPT.md
+++ b/docs/LETS_ENCRYPT.md
@@ -1,0 +1,80 @@
+# Let's Encrypt Setup
+
+This document explains how to obtain trusted TLS certificates using Certbot.
+
+## 1. Verify DNS
+
+Ensure that the A record from [DNS_SETUP.md](DNS_SETUP.md) already points to your server. The HTTP challenge will be served from this host.
+
+```bash
+# should return the server IP
+nslookup english.webhop.me
+```
+
+## 2. Install Certbot
+
+Certbot can run in a Docker container. Pull the image first:
+
+```bash
+docker pull certbot/certbot
+```
+
+Create a directory for challenge files and certificates if it does not exist:
+
+```bash
+mkdir -p infra/nginx/www infra/nginx/certs
+```
+
+## 3. Obtain the certificate
+
+Run Certbot with the `webroot` plugin. The `nginx` service must be running so that
+`/.well-known/acme-challenge` is reachable on port 80.
+
+```bash
+docker run --rm \
+  -v "$PWD/infra/nginx/www:/var/www/certbot" \
+  -v "$PWD/infra/nginx/certs:/etc/letsencrypt" \
+  certbot/certbot certonly \
+    --webroot -w /var/www/certbot \
+    -d english.webhop.me
+```
+
+After success copy the resulting files:
+
+```bash
+cp infra/nginx/certs/live/english.webhop.me/fullchain.pem infra/nginx/certs/server.crt
+cp infra/nginx/certs/live/english.webhop.me/privkey.pem infra/nginx/certs/server.key
+```
+
+## 4. Automatic renewal
+
+Create a systemd timer or cron job that runs the same Docker command with the
+`renew` subcommand:
+
+```bash
+0 3 * * * docker run --rm \
+  -v /path/to/repo/infra/nginx/www:/var/www/certbot \
+  -v /path/to/repo/infra/nginx/certs:/etc/letsencrypt \
+  certbot/certbot renew --quiet
+```
+
+After renewal restart the containers to pick up the new certificates:
+
+```bash
+docker compose -f infra/docker-compose.yml restart nginx
+```
+
+## 5. Restart services
+
+When the certificate is obtained for the first time (or after renewal) reload
+NGINX:
+
+```bash
+docker compose -f infra/docker-compose.yml exec nginx nginx -s reload
+```
+
+If NGINX is not running yet start the full stack:
+
+```bash
+make up
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ This directory contains all NGINX related documents. Each file focuses on a spec
 - `NGINX_TRAINING.md` – training materials for developers and SREs.
 - `DNS_SETUP.md` – required DNS records for production deployment.
 - `SMTP_CONFIGURATION.md` – environment variables for outgoing email
+- `LETS_ENCRYPT.md` – obtaining trusted TLS certificates
 - `../infra/dns` – BIND zone files reflecting the recommended records.
 
 Documentation is reviewed **quarterly**. The SRE Lead tracks outdated sections and opens issues for updates.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -57,6 +57,7 @@ services:
     volumes:
       - ./nginx/nginx.conf.template:/etc/nginx/templates/nginx.conf.template:ro
       - ./nginx/certs:/etc/nginx/certs:ro
+      - ./nginx/www:/var/www/certbot:ro
     ports:
       - "80:80"
       - "443:443"

--- a/infra/nginx/certs/README.md
+++ b/infra/nginx/certs/README.md
@@ -1,5 +1,6 @@
 This directory should contain `server.crt` and `server.key` for HTTPS termination.
-Use a trusted certificate in production or generate a self-signed pair for local testing:
+In production copy the `fullchain.pem` and `privkey.pem` issued by Let's Encrypt
+to these files. For local development you can generate a self-signed pair:
 
 ```bash
 openssl req -x509 -newkey rsa:2048 -nodes -keyout server.key -out server.crt -days 365 -subj "/CN=localhost"

--- a/infra/nginx/nginx.conf.template
+++ b/infra/nginx/nginx.conf.template
@@ -32,7 +32,14 @@ http {
     server {
         listen 80;
         server_name english.webhop.me;
-        return 301 https://$host$request_uri;
+
+        location ^~ /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+        }
+
+        location / {
+            return 301 https://$host$request_uri;
+        }
     }
 
     server {

--- a/infra/nginx/www/README.md
+++ b/infra/nginx/www/README.md
@@ -1,0 +1,2 @@
+This directory stores challenge files for Let's Encrypt when using the webroot plugin.
+It is mounted into the Nginx container at /var/www/certbot.


### PR DESCRIPTION
## Summary
- document getting trusted TLS certificates with Let's Encrypt
- update docs listing
- mount challenge directory in nginx container
- handle ACME challenge in nginx config
- clarify where to place fullchain/privkey files

## Testing
- `./gradlew test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6847dd9f5d108326a6a3d9613b998760