### PR TITLE
Automate Let's Encrypt certificate retrieval

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,6 +70,7 @@ jobs:
     env:
       # Store files in the user's home directory
       DEPLOY_DIR: myapp
+      CERTBOT_EMAIL: ${{ secrets.CERTBOT_EMAIL }}
 
     steps:
     # 1. Клонируем репозиторий
@@ -157,7 +158,7 @@ jobs:
         # port:     ${{ secrets.VPS_PORT }}
         # Передаём на сервер не только Dockerfile и compose, но и исходники
         # бэкенда, чтобы Docker смог собрать jar внутри контейнера
-        source: "backend,infra/docker-compose.yml,infra/.env.example,scripts/wait-for-db.sh,infra/nginx/nginx.conf,infra/prometheus/prometheus.yml"
+        source: "backend,infra/docker-compose.yml,infra/.env.example,scripts/wait-for-db.sh,scripts/letsencrypt.sh,infra/nginx/nginx.conf,infra/prometheus/prometheus.yml"
         target: ${{ env.DEPLOY_DIR }}
         rm:     true
 
@@ -199,7 +200,7 @@ jobs:
         username:   ${{ secrets.VPS_USER }}
         password:   ${{ secrets.VPS_PASSWORD }}
         # port:     ${{ secrets.VPS_PORT }}
-        envs: DEPLOY_DIR
+        envs: DEPLOY_DIR,CERTBOT_EMAIL
         script: |
           set -e
           cd "$HOME/$DEPLOY_DIR"
@@ -212,3 +213,15 @@ jobs:
           docker compose -f infra/docker-compose.yml up -d --wait
           docker compose -f infra/docker-compose.yml ps
           docker compose -f infra/docker-compose.yml logs app --tail=20
+
+    - name: Obtain TLS certificate
+      uses: appleboy/ssh-action@v1.0.0
+      with:
+        host:       ${{ secrets.VPS_HOST }}
+        username:   ${{ secrets.VPS_USER }}
+        password:   ${{ secrets.VPS_PASSWORD }}
+        # port:     ${{ secrets.VPS_PORT }}
+        envs: DEPLOY_DIR,CERTBOT_EMAIL
+        script: |
+          cd "$HOME/$DEPLOY_DIR"
+          bash scripts/letsencrypt.sh

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@
    длиной не менее 32 байт, например `openssl rand -hex 32`.
    При необходимости измените `SPRING_PROFILES_ACTIVE`, `DB_HOST` и `DB_PORT`.
    Переменная `DB_HOST` по умолчанию равна `db`, но её можно переопределить.
+   Укажите `CERTBOT_EMAIL` для получения сертификата Let's Encrypt.
    Файл автоматически читается `docker compose` из `infra/.env`. Если переменная
    не задана, `docker compose` завершится ошибкой `JWT_SECRET: set JWT_SECRET in .env`.
    Файл добавлен в `.gitignore` и хранится локально.
@@ -93,8 +94,8 @@
    ./backend/gradlew clean bootJar
    ```
 
-3. Создайте сертификат для Nginx. Выполните команду из корня репозитория,
-   чтобы итоговые файлы оказались в каталоге `infra/nginx/certs`:
+3. Для локального запуска требуется самоподписанный сертификат. Его можно
+   сгенерировать командой:
 
    ```bash
    mkdir -p infra/nginx/certs && cd <repo-root>
@@ -103,6 +104,8 @@
      -out infra/nginx/certs/server.crt \
      -days 365 -subj "/CN=localhost"
    ```
+   В production настоящий сертификат выдаётся автоматически скриптом
+   `scripts/letsencrypt.sh`, который запускает deploy workflow.
 4. Соберите и запустите контейнеры через Makefile. Он использует
    `infra/docker-compose.yml`:
 
@@ -282,6 +285,7 @@ SPA. Готовый каталог можно раздавать через NGIN
 - `VPS_PASSWORD` – пароль пользователя;
 - `VPS_PORT` – SSH‑порт, если отличается от `22`;
 - `PROXY_HOST` и `PROXY_PORT` – при необходимости использовать сетевой прокси.
+- `CERTBOT_EMAIL` – адрес для регистрации сертификата Let's Encrypt.
 
 Workflow собирает JAR, автоматически строит SPA и CSS, копирует получившиеся файлы и инфраструктуру на сервер и запускает `docker compose -f infra/docker-compose.yml up -d`.
 Сервер должен иметь установленный Docker версии **27.5.1** или новее (API 1.47), так как деплой тестировался на этой версии.

--- a/docs/LETS_ENCRYPT.md
+++ b/docs/LETS_ENCRYPT.md
@@ -1,6 +1,10 @@
 # Let's Encrypt Setup
 
-This document explains how to obtain trusted TLS certificates using Certbot.
+This document explains how trusted TLS certificates are obtained using Certbot.
+The GitHub Actions deployment workflow automatically executes
+`scripts/letsencrypt.sh` on the server. The script requests a certificate via the
+webroot plugin and reloads NGINX when finished. Manual steps are kept below for
+reference.
 
 ## 1. Verify DNS
 
@@ -27,23 +31,11 @@ mkdir -p infra/nginx/www infra/nginx/certs
 
 ## 3. Obtain the certificate
 
-Run Certbot with the `webroot` plugin. The `nginx` service must be running so that
-`/.well-known/acme-challenge` is reachable on port 80.
+If needed you can invoke the helper script manually. It ensures NGINX is
+running, requests a certificate and copies it into `infra/nginx/certs`:
 
 ```bash
-docker run --rm \
-  -v "$PWD/infra/nginx/www:/var/www/certbot" \
-  -v "$PWD/infra/nginx/certs:/etc/letsencrypt" \
-  certbot/certbot certonly \
-    --webroot -w /var/www/certbot \
-    -d english.webhop.me
-```
-
-After success copy the resulting files:
-
-```bash
-cp infra/nginx/certs/live/english.webhop.me/fullchain.pem infra/nginx/certs/server.crt
-cp infra/nginx/certs/live/english.webhop.me/privkey.pem infra/nginx/certs/server.key
+scripts/letsencrypt.sh
 ```
 
 ## 4. Automatic renewal

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -8,6 +8,7 @@ DB_PORT=5432
 # Replace this value with a strong random string before deploying
 JWT_SECRET=0123456789abcdef0123456789abcdef
 SERVER_NAME=english.webhop.me
+CERTBOT_EMAIL=admin@example.com
 SMTP_HOST=localhost
 SMTP_PORT=25
 SMTP_USERNAME=

--- a/scripts/letsencrypt.sh
+++ b/scripts/letsencrypt.sh
@@ -8,7 +8,7 @@ certdir="$repo_root/infra/nginx/certs"
 mkdir -p "$webroot" "$certdir"
 
 domain="${DOMAIN:-${SERVER_NAME:-english.webhop.me}}"
-email="${CERTBOT_EMAIL:-izumi.katsu667@gmail.com}"
+email="${CERTBOT_EMAIL:-admin@example.com}"
 
 if [ ! -f "$certdir/server.crt" ] || [ ! -f "$certdir/server.key" ]; then
   openssl req -x509 -newkey rsa:2048 -nodes \


### PR DESCRIPTION
## Summary
- run certbot via `scripts/letsencrypt.sh` automatically during deployment
- add CERTBOT_EMAIL to infra example env
- document automatic certificate handling

## Testing
- `./backend/gradlew test`
- `npm ci && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68480fa069948326a13cf3cc9c2391bb