### PR TITLE
Switch domain to crm-synergy.ru

### DIFF
--- a/docs/DNS_SETUP.md
+++ b/docs/DNS_SETUP.md
@@ -6,6 +6,6 @@ This document describes the DNS records required to run the application in produ
 
 | Name | Type | Value | Notes |
 | --- | --- | --- | --- |
-| `english.webhop.me` | A | `45.15.170.22` | Main entry point |
+| `crm-synergy.ru` | A | `45.15.170.22` | Main entry point |
 
 

--- a/docs/LETS_ENCRYPT.md
+++ b/docs/LETS_ENCRYPT.md
@@ -8,7 +8,7 @@ Ensure that the A record from [DNS_SETUP.md](DNS_SETUP.md) already points to you
 
 ```bash
 # should return the server IP
-nslookup english.webhop.me
+nslookup crm-synergy.ru
 ```
 
 ## 2. Install Certbot
@@ -36,14 +36,14 @@ docker run --rm \
   -v "$PWD/infra/nginx/certs:/etc/letsencrypt" \
   certbot/certbot certonly \
     --webroot -w /var/www/certbot \
-    -d english.webhop.me
+    -d crm-synergy.ru
 ```
 
 After success copy the resulting files:
 
 ```bash
-cp infra/nginx/certs/live/english.webhop.me/fullchain.pem infra/nginx/certs/server.crt
-cp infra/nginx/certs/live/english.webhop.me/privkey.pem infra/nginx/certs/server.key
+cp infra/nginx/certs/live/crm-synergy.ru/fullchain.pem infra/nginx/certs/server.crt
+cp infra/nginx/certs/live/crm-synergy.ru/privkey.pem infra/nginx/certs/server.key
 ```
 
 ## 4. Automatic renewal

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,1 @@
-VITE_API_URL=http://localhost:8080
+VITE_API_URL=https://crm-synergy.ru

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   envPrefix: 'VITE_',
   server: {
     proxy: {
-      '/api': 'http://localhost:8080',
+      '/api': 'https://crm-synergy.ru',
     },
   },
 })

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -7,7 +7,7 @@ DB_HOST=db
 DB_PORT=5432
 # Replace this value with a strong random string before deploying
 JWT_SECRET=0123456789abcdef0123456789abcdef
-SERVER_NAME=english.webhop.me
+SERVER_NAME=crm-synergy.ru
 SMTP_HOST=localhost
 SMTP_PORT=25
 SMTP_USERNAME=

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     environment:
       APP_HOST: ${APP_HOST:-app}
       APP_PORT: 8080
-      SERVER_NAME: ${SERVER_NAME:-english.webhop.me}
+      SERVER_NAME: ${SERVER_NAME:-crm-synergy.ru}
     entrypoint: >
       /bin/sh -c "
         envsubst '\$${APP_HOST} \$${APP_PORT} \$${SERVER_NAME}' \

--- a/scripts/letsencrypt.sh
+++ b/scripts/letsencrypt.sh
@@ -7,7 +7,7 @@ certdir="$repo_root/infra/nginx/certs"
 
 mkdir -p "$webroot" "$certdir"
 
-domain="${DOMAIN:-${SERVER_NAME:-english.webhop.me}}"
+domain="${DOMAIN:-${SERVER_NAME:-crm-synergy.ru}}"
 email="${CERTBOT_EMAIL:-izumi.katsu667@gmail.com}"
 
 if [ ! -f "$certdir/server.crt" ] || [ ! -f "$certdir/server.key" ]; then


### PR DESCRIPTION
## Summary
- update docs and configuration files to use `crm-synergy.ru`
- set the default API URL for the frontend example env
- change Vite dev proxy target

## Testing
- `npm ci`
- `npm run lint`
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684844b9e6108326b47b676e87a93ad5