### PR TITLE
Load env vars from .env for docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@
 
 1. Создайте файл `infra/.env` на основе переменных из [docs/ENVIRONMENT.md](docs/ENVIRONMENT.md).
    Сгенерируйте надёжное значение `JWT_SECRET`, например `openssl rand -hex 32`.
-   При необходимости скорректируйте `SPRING_PROFILES_ACTIVE`, `DB_HOST` и `DB_PORT`.
+   Все сервисы Docker Compose читают переменные из этого файла. При необходимости
+   скорректируйте `SPRING_PROFILES_ACTIVE`, `DB_HOST` и `DB_PORT`.
    `docker compose` автоматически считывает `infra/.env`, а сам файл исключён из индекса Git.
 2. Соберите production артефакты:
    ```bash

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -9,6 +9,9 @@ The backend relies on the following variables. They **must** be provided when ru
 | `DB_USER` | Database username |
 | `DB_PASSWORD` | Database password |
 | `DB_NAME` | Database name |
+| `POSTGRES_DB` | PostgreSQL database name |
+| `POSTGRES_USER` | PostgreSQL user |
+| `POSTGRES_PASSWORD` | PostgreSQL password |
 | `SMTP_HOST` | SMTP server hostname |
 | `SMTP_PORT` | SMTP server port |
 | `SMTP_USERNAME` | SMTP account username |
@@ -18,5 +21,8 @@ The backend relies on the following variables. They **must** be provided when ru
 | `MAIL_FROM` | Sender address for outgoing mail |
 | `TELEGRAM_BOT_TOKEN` | Telegram bot token |
 | `JWT_SECRET` | Secret key used to sign JWT tokens |
+| `APP_HOST` | Hostname of the backend container for Nginx |
+| `APP_PORT` | Port of the backend container |
+| `SERVER_NAME` | Domain served by Nginx |
 
 Place these variables in `infra/.env` for Docker Compose or export them in the shell before running the application locally.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -3,10 +3,11 @@ services:
   db:
     # Fresh PostgreSQL instance
     image: postgres:16.2
+    env_file: ./.env
     environment:
-      POSTGRES_DB: schedule
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     ports:
       - "5432:5432"
     healthcheck:
@@ -24,9 +25,9 @@ services:
         condition: service_healthy
     env_file: ./.env
     environment:
-      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-postgres}
-      DB_HOST: ${DB_HOST:-db}
-      DB_PORT: ${DB_PORT:-5432}
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE}
+      DB_HOST: ${DB_HOST}
+      DB_PORT: ${DB_PORT}
       JWT_SECRET: ${JWT_SECRET}
     restart: unless-stopped
     healthcheck:
@@ -44,10 +45,11 @@ services:
       app:
         condition: service_healthy
     restart: unless-stopped
+    env_file: ./.env
     environment:
-      APP_HOST: ${APP_HOST:-app}
-      APP_PORT: 8080
-      SERVER_NAME: ${SERVER_NAME:-crm-synergy.ru}
+      APP_HOST: ${APP_HOST}
+      APP_PORT: ${APP_PORT}
+      SERVER_NAME: ${SERVER_NAME}
     entrypoint: >
       /bin/sh -c "
         envsubst '\$${APP_HOST} \$${APP_PORT} \$${SERVER_NAME}' \


### PR DESCRIPTION
## Summary
- update docker-compose to load database credentials and host settings from `.env`
- document additional variables in `docs/ENVIRONMENT.md`
- clarify in README that all services read variables from `infra/.env`

## Testing
- `./backend/gradlew -p backend test --no-daemon` *(fails: Directory '/workspace/trash' does not contain a Gradle build)*
- `npm --prefix frontend run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68487f7684808326999cd4e71a1d8870