### PR TITLE
Fix Nginx TLS config generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -157,7 +157,7 @@ jobs:
     # Render environment-specific nginx.conf
     - name: Render NGINX config
       run: |
-        APP_HOST=app APP_PORT=8080 ./scripts/render-nginx.sh
+        APP_HOST=app APP_PORT=8080 SERVER_NAME=example.com ./scripts/render-nginx.sh
 
     # Validate NGINX configuration syntax
     - name: Validate NGINX config

--- a/README.md
+++ b/README.md
@@ -154,8 +154,9 @@ docker ps -aq --filter "label=com.docker.compose.project=infra" | xargs -r docke
 Контейнер `app` используется как в production, так и при локальной разработке.
 `nginx` запускается вместе с приложением и автоматически ждёт готовности бэкенда.
 
-При запуске `nginx` отдельно задайте `APP_HOST` и `APP_PORT` для указания адреса
-бэкенда. Контейнер подставит их в `nginx.conf.template`.
+При запуске `nginx` отдельно задайте `APP_HOST`, `APP_PORT` и `SERVER_NAME` для
+указания адреса бэкенда и домена, который будет использован в конфигурации
+`nginx.conf.template`.
 
 После старта веб-интерфейс доступен на `https://localhost` (порт `443`),
 обращения к `http://localhost` перенаправляются на HTTPS.

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -23,7 +23,7 @@ All configuration is provided via environment variables. Create `infra/.env` and
 | `JWT_SECRET` | `0123456789abcdef0123456789abcdef` | `backend/src/main/resources/application.yml`, `infra/docker-compose.yml` | `infra/.env` or secrets |
 | `APP_HOST` | `app` | `infra/nginx/nginx.conf.template`, `infra/docker-compose.yml`, `scripts/render-nginx.sh` | `infra/.env` |
 | `APP_PORT` | `8080` | `infra/nginx/nginx.conf.template`, `infra/docker-compose.yml`, `scripts/render-nginx.sh` | `infra/.env` |
-| `SERVER_NAME` | `example.com` | `infra/nginx/nginx.conf.template`, `infra/docker-compose.yml`, `scripts/letsencrypt.sh` | `infra/.env` |
+| `SERVER_NAME` | `example.com` | `infra/nginx/nginx.conf.template`, `infra/docker-compose.yml`, `scripts/render-nginx.sh`, `scripts/letsencrypt.sh` | `infra/.env` |
 | `SPRING_PROFILES_ACTIVE` | `postgres` | `infra/docker-compose.yml` | `infra/.env` |
 | `PROXY_HOST` | `proxy.example.com` | `scripts/setup-proxy.sh`, `.github/workflows/deploy.yml` | secrets or shell |
 | `PROXY_PORT` | `8080` | `scripts/setup-proxy.sh`, `.github/workflows/deploy.yml` | secrets or shell |

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       /bin/sh -c "
         envsubst '\$${APP_HOST} \$${APP_PORT} \$${SERVER_NAME}' \
           < /etc/nginx/templates/nginx.conf.template \
-          > /etc/nginx/conf.d/default.conf &&
+          > /etc/nginx/nginx.conf &&
         exec nginx -g 'daemon off;'
       "
     volumes:

--- a/scripts/render-nginx.sh
+++ b/scripts/render-nginx.sh
@@ -2,5 +2,7 @@
 set -e
 : "${APP_HOST:?APP_HOST is required}"
 : "${APP_PORT:?APP_PORT is required}"
+: "${SERVER_NAME:?SERVER_NAME is required}"
 
-envsubst '${APP_HOST} ${APP_PORT}' < infra/nginx/nginx.conf.template > infra/nginx/nginx.conf
+envsubst '${APP_HOST} ${APP_PORT} ${SERVER_NAME}' \
+  < infra/nginx/nginx.conf.template > infra/nginx/nginx.conf


### PR DESCRIPTION
## Summary
- ensure `SERVER_NAME` is substituted when rendering Nginx config
- generate final config as `/etc/nginx/nginx.conf`
- document required variables for Nginx
- mention `SERVER_NAME` in README
- run backend tests

## Testing
- `./backend/gradlew test`
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6848a88e31bc83268bab8a899b0c130f