### PR TITLE
Fix TLS secrets decoding

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -130,34 +130,49 @@ jobs:
       run: |
         mkdir -p infra/nginx/certs
 
-        write_file() {
-          local value="$1"
-          local dest="$2"
-          if [ -z "$value" ]; then
-            echo "::error::Missing secret for $dest" >&2
-            exit 1
-          fi
-
-          if printf '%s' "$value" | base64 --decode --ignore-garbage > "$dest" 2>/dev/null; then
-            echo "decoded $dest"
+        write_secret_file() {
+          local name=$1 content=$2
+          mkdir -p infra/nginx/certs
+          if [[ $content == -----BEGIN* ]]; then
+            printf '%s\n' "$content" > "infra/nginx/certs/$name"
           else
-            printf '%s' "$value" > "$dest"
+            printf '%s' "$content" | base64 -d > "infra/nginx/certs/$name"
+            ( tail -c1 "infra/nginx/certs/$name" | read -r _ ) || echo >> "infra/nginx/certs/$name"
           fi
         }
 
-        write_file "${{ secrets.SSL_CERT }}" infra/nginx/certs/crm-synergy.crt
-        write_file "${{ secrets.SSL_KEY }}"  infra/nginx/certs/crm-synergy.key
+        write_secret_file crm-synergy.crt "${{ secrets.SSL_CERT }}"
+        write_secret_file crm-synergy.key "${{ secrets.SSL_KEY }}"
+        if [ -n "${{ secrets.SSL_CA_CERT }}" ]; then
+          write_secret_file crm-synergy_ca.crt "${{ secrets.SSL_CA_CERT }}"
+        fi
 
         chmod 600 infra/nginx/certs/crm-synergy.key
 
         # verify the key to catch invalid input early
         openssl pkey -in infra/nginx/certs/crm-synergy.key -noout >/dev/null
+
+        if [ -f infra/nginx/certs/crm-synergy_ca.crt ]; then
+          {
+            cat infra/nginx/certs/crm-synergy.crt
+            printf '\n'
+            cat infra/nginx/certs/crm-synergy_ca.crt
+          } > infra/nginx/certs/fullchain.pem
+        else
+          cp infra/nginx/certs/crm-synergy.crt infra/nginx/certs/fullchain.pem
+        fi
+
+        openssl x509 -noout -in infra/nginx/certs/fullchain.pem
+        if [ -f infra/nginx/certs/crm-synergy_ca.crt ]; then
+          openssl verify -CAfile infra/nginx/certs/crm-synergy_ca.crt \
+                         infra/nginx/certs/crm-synergy.crt
+        fi
       shell: bash
 
     # Render environment-specific nginx.conf
     - name: Render NGINX config
       run: |
-        APP_HOST=app APP_PORT=8080 ./scripts/render-nginx.sh
+        APP_HOST=app APP_PORT=8080 SERVER_NAME=example.com ./scripts/render-nginx.sh
 
     # Validate NGINX configuration syntax
     - name: Validate NGINX config

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -23,7 +23,7 @@ All configuration is provided via environment variables. Create `infra/.env` and
 | `JWT_SECRET` | `0123456789abcdef0123456789abcdef` | `backend/src/main/resources/application.yml`, `infra/docker-compose.yml` | `infra/.env` or secrets |
 | `APP_HOST` | `app` | `infra/nginx/nginx.conf.template`, `infra/docker-compose.yml`, `scripts/render-nginx.sh` | `infra/.env` |
 | `APP_PORT` | `8080` | `infra/nginx/nginx.conf.template`, `infra/docker-compose.yml`, `scripts/render-nginx.sh` | `infra/.env` |
-| `SERVER_NAME` | `example.com` | `infra/nginx/nginx.conf.template`, `infra/docker-compose.yml`, `scripts/letsencrypt.sh` | `infra/.env` |
+| `SERVER_NAME` | `example.com` | `infra/nginx/nginx.conf.template`, `infra/docker-compose.yml`, `scripts/render-nginx.sh`, `scripts/letsencrypt.sh` | `infra/.env` |
 | `SPRING_PROFILES_ACTIVE` | `postgres` | `infra/docker-compose.yml` | `infra/.env` |
 | `PROXY_HOST` | `proxy.example.com` | `scripts/setup-proxy.sh`, `.github/workflows/deploy.yml` | secrets or shell |
 | `PROXY_PORT` | `8080` | `scripts/setup-proxy.sh`, `.github/workflows/deploy.yml` | secrets or shell |
@@ -38,6 +38,7 @@ All configuration is provided via environment variables. Create `infra/.env` and
 | `VPS_PORT` | `22` | `.github/workflows/deploy.yml` | secrets |
 | `CERTBOT_EMAIL` | `admin@example.com` | `scripts/letsencrypt.sh` | shell |
 | `DOMAIN` | `example.com` | `scripts/letsencrypt.sh` | shell |
-| `SSL_CERT` | _(output of `base64 -w0` on crm-synergy.crt)_ | `.github/workflows/deploy.yml` | secrets/vars |
+| `SSL_CERT` | _(output of `base64 -w0` on fullchain.pem)_ | `.github/workflows/deploy.yml` | secrets/vars |
 | `SSL_KEY`  | _(output of `base64 -w0` on crm-synergy.key)_ | `.github/workflows/deploy.yml` | secrets/vars |
+| `SSL_CA_CERT` | _(optional CA certificate)_ | `.github/workflows/deploy.yml` | secrets/vars |
 

--- a/docs/LETS_ENCRYPT.md
+++ b/docs/LETS_ENCRYPT.md
@@ -42,14 +42,14 @@ docker run --rm \
 After success copy the resulting files:
 
 ```bash
-cp infra/nginx/certs/live/crm-synergy.ru/fullchain.pem infra/nginx/certs/crm-synergy.crt
+cp infra/nginx/certs/live/crm-synergy.ru/fullchain.pem infra/nginx/certs/fullchain.pem
 cp infra/nginx/certs/live/crm-synergy.ru/privkey.pem infra/nginx/certs/crm-synergy.key
 ```
 
 Encode the files in a single line before storing them as secrets:
 
 ```bash
-base64 -w0 infra/nginx/certs/crm-synergy.crt > cert.b64
+base64 -w0 infra/nginx/certs/fullchain.pem > cert.b64
 base64 -w0 infra/nginx/certs/crm-synergy.key > key.b64
 ```
 

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       /bin/sh -c "
         envsubst '\$${APP_HOST} \$${APP_PORT} \$${SERVER_NAME}' \
           < /etc/nginx/templates/nginx.conf.template \
-          > /etc/nginx/conf.d/default.conf &&
+          > /etc/nginx/nginx.conf &&
         exec nginx -g 'daemon off;'
       "
     volumes:

--- a/infra/nginx/certs/README.md
+++ b/infra/nginx/certs/README.md
@@ -1,10 +1,10 @@
-This directory should contain `crm-synergy.crt` and `crm-synergy.key` for HTTPS termination.
-Use the `fullchain.pem` and `privkey.pem` issued by Let's Encrypt for production deployments.
+This directory should contain `fullchain.pem` and `crm-synergy.key` for HTTPS termination.
+Use the certificate bundle provided by your CA together with the matching private key.
 On CI the files are created from the `SSL_CERT` and `SSL_KEY` secrets. Store the
-output of `base64 -w0` for `crm-synergy.crt` and `crm-synergy.key` in those
+output of `base64 -w0` for `fullchain.pem` and `crm-synergy.key` in those
 variables.
 To test locally you can generate a self-signed pair:
 
 ```bash
-openssl req -x509 -newkey rsa:2048 -nodes -keyout crm-synergy.key -out crm-synergy.crt -days 365 -subj "/CN=localhost"
+openssl req -x509 -newkey rsa:2048 -nodes -keyout crm-synergy.key -out fullchain.pem -days 365 -subj "/CN=localhost"
 ```

--- a/infra/nginx/nginx.conf.template
+++ b/infra/nginx/nginx.conf.template
@@ -43,10 +43,10 @@ http {
     }
 
     server {
-        listen 443 ssl;
-        http2 on;
+        # HTTP/2 is enabled via the listen directive
+        listen 443 ssl http2;
         server_name ${SERVER_NAME};
-        ssl_certificate /etc/nginx/certs/crm-synergy.crt;
+        ssl_certificate /etc/nginx/certs/fullchain.pem;
         ssl_certificate_key /etc/nginx/certs/crm-synergy.key;
         ssl_protocols TLSv1.2 TLSv1.3;
         ssl_prefer_server_ciphers on;

--- a/scripts/letsencrypt.sh
+++ b/scripts/letsencrypt.sh
@@ -10,10 +10,10 @@ mkdir -p "$webroot" "$certdir"
 domain="${DOMAIN:-${SERVER_NAME:-crm-synergy.ru}}"
 email="${CERTBOT_EMAIL:-izumi.katsu667@gmail.com}"
 
-if [ ! -f "$certdir/crm-synergy.crt" ] || [ ! -f "$certdir/crm-synergy.key" ]; then
+if [ ! -f "$certdir/fullchain.pem" ] || [ ! -f "$certdir/crm-synergy.key" ]; then
   openssl req -x509 -newkey rsa:2048 -nodes \
     -keyout "$certdir/crm-synergy.key" \
-    -out "$certdir/crm-synergy.crt" \
+    -out "$certdir/fullchain.pem" \
     -days 1 -subj "/CN=$domain"
 fi
 
@@ -32,7 +32,7 @@ docker run --rm \
     -m "$email" \
     -d "$domain"
 
-cp "$certdir/live/$domain/fullchain.pem" "$certdir/crm-synergy.crt"
+cp "$certdir/live/$domain/fullchain.pem" "$certdir/fullchain.pem"
 cp "$certdir/live/$domain/privkey.pem" "$certdir/crm-synergy.key"
 
 docker compose -f "$repo_root/infra/docker-compose.yml" exec nginx nginx -s reload

--- a/scripts/render-nginx.sh
+++ b/scripts/render-nginx.sh
@@ -2,5 +2,7 @@
 set -e
 : "${APP_HOST:?APP_HOST is required}"
 : "${APP_PORT:?APP_PORT is required}"
+: "${SERVER_NAME:?SERVER_NAME is required}"
 
-envsubst '${APP_HOST} ${APP_PORT}' < infra/nginx/nginx.conf.template > infra/nginx/nginx.conf
+envsubst '${APP_HOST} ${APP_PORT} ${SERVER_NAME}' \
+  < infra/nginx/nginx.conf.template > infra/nginx/nginx.conf


### PR DESCRIPTION
## Summary
- improve certificate handling in deploy workflow
- optional `SSL_CA_CERT` support
- verify certificate chain during CI
- document new secret
- fix HTTP/2 directive in Nginx template and update certificate filenames

## Testing
- `./backend/gradlew test`
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6848a88e31bc83268bab8a899b0c130f