### PR TITLE
Fix compose defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,12 @@
 
 Полный перечень переменных приведён в [docs/ENVIRONMENT.md](docs/ENVIRONMENT.md).
 
-1. Создайте файл `infra/.env` на основе переменных из [docs/ENVIRONMENT.md](docs/ENVIRONMENT.md).
-   Файл `.env.example` больше не поставляется, поэтому `.env` нужно создать вручную.
-   Сгенерируйте надёжное значение `JWT_SECRET`, например `openssl rand -hex 32`.
-   Все сервисы Docker Compose читают переменные из этого файла. При необходимости
-   скорректируйте `SPRING_PROFILES_ACTIVE`, `DB_HOST` и `DB_PORT`.
-   `docker compose` автоматически считывает `infra/.env`, а сам файл исключён из индекса Git.
+1. При необходимости создайте файл `infra/.env` на основе переменных из
+   [docs/ENVIRONMENT.md](docs/ENVIRONMENT.md). Значения для `POSTGRES_*` и других
+   переменных имеют безопасные defaults, поэтому файл можно опустить для локального
+   запуска. Чтобы использовать собственный секрет, сгенерируйте `JWT_SECRET`,
+   например `openssl rand -hex 32`. `docker compose` автоматически считывает
+   `infra/.env`, а сам файл исключён из индекса Git.
 2. Соберите production артефакты:
    ```bash
    npm --prefix frontend ci

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -1,6 +1,11 @@
 # Environment Variables
 
-All configuration is provided via environment variables. Create `infra/.env` and `frontend/.env` manually—`.env.example` is no longer part of the workflow. The table below lists each variable, an example value, where it is used and the recommended storage location.
+All configuration is provided via environment variables. Create `infra/.env` and
+`frontend/.env` manually if you need to override the defaults—`.env.example` is
+no longer part of the workflow. The table below lists each variable, an example
+value, where it is used and the recommended storage location. When a variable is
+not defined, Docker Compose falls back to sensible defaults suitable for local
+development.
 
 | Variable | Example | Consumed In | Location |
 | --- | --- | --- | --- |

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -5,9 +5,9 @@ services:
     image: postgres:16.2
     env_file: ./.env
     environment:
-      POSTGRES_DB: ${POSTGRES_DB}
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB:-schedule}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
     ports:
       - "5432:5432"
     healthcheck:
@@ -25,10 +25,13 @@ services:
         condition: service_healthy
     env_file: ./.env
     environment:
-      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE}
-      DB_HOST: ${DB_HOST}
-      DB_PORT: ${DB_PORT}
-      JWT_SECRET: ${JWT_SECRET}
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-postgres}
+      DB_HOST: ${DB_HOST:-db}
+      DB_PORT: ${DB_PORT:-5432}
+      DB_NAME: ${DB_NAME:-schedule}
+      DB_USER: ${DB_USER:-postgres}
+      DB_PASSWORD: ${DB_PASSWORD:-postgres}
+      JWT_SECRET: ${JWT_SECRET:-secret}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
@@ -47,9 +50,9 @@ services:
     restart: unless-stopped
     env_file: ./.env
     environment:
-      APP_HOST: ${APP_HOST}
-      APP_PORT: ${APP_PORT}
-      SERVER_NAME: ${SERVER_NAME}
+      APP_HOST: ${APP_HOST:-app}
+      APP_PORT: ${APP_PORT:-8080}
+      SERVER_NAME: ${SERVER_NAME:-localhost}
     entrypoint: >
       /bin/sh -c "
         envsubst '\$${APP_HOST} \$${APP_PORT} \$${SERVER_NAME}' \


### PR DESCRIPTION
## Summary
- set default environment values in Docker Compose
- clarify optional infra/.env usage in docs

## Testing
- `./backend/gradlew test --no-daemon`
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6848ccd2be548326a3ba8c4794686476