### PR TITLE
Fix JWT secret fallback

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -22,7 +22,9 @@ telegram:
   bot-token: ${TELEGRAM_BOT_TOKEN}
 
 jwt:
-  secret: ${JWT_SECRET}
+  # Use a secure random key in production. Fallback string is suitable for local
+  # development but won't work if trimmed below 32 bytes.
+  secret: ${JWT_SECRET:0123456789abcdef0123456789abcdef}
 
 management:
   health:


### PR DESCRIPTION
## Summary
- provide default JWT secret for local development in `application.yml`

## Testing
- `./backend/gradlew --no-daemon spotlessApply test`

------
https://chatgpt.com/codex/tasks/task_e_6849160ff59083269fdabb8f10857321