### PR TITLE
Add frontend build step to CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,15 @@ jobs:
           PROXY_HOST: ${{ secrets.PROXY_HOST }}
           PROXY_PORT: ${{ secrets.PROXY_PORT }}
 
+      - name: Build frontend
+        run: cd frontend && npm ci && npm run build
+
+      - name: Copy dist to nginx
+        run: |
+          rm -rf infra/nginx/www
+          mkdir -p infra/nginx/www
+          cp -r frontend/dist/* infra/nginx/www/
+
       - name: Build backend with tests
         run: ./gradlew build
         working-directory: backend
@@ -119,6 +128,15 @@ jobs:
       env:
         PROXY_HOST: ${{ secrets.PROXY_HOST }}
         PROXY_PORT: ${{ secrets.PROXY_PORT }}
+
+    - name: Build frontend
+      run: cd frontend && npm ci && npm run build
+
+    - name: Copy dist to nginx
+      run: |
+        rm -rf infra/nginx/www
+        mkdir -p infra/nginx/www
+        cp -r frontend/dist/* infra/nginx/www/
 
     # 4. Запускаем тесты и собираем JAR
     - name: Build backend with tests


### PR DESCRIPTION
## Summary
- build frontend before running backend builds in CI
- copy build output to `infra/nginx/www` for Nginx container

## Testing
- `./backend/gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6849451b4f4c8326b35ba61bfb924e2b