### PR TITLE
Fix Docker Hub login in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -281,6 +281,9 @@ jobs:
     # 7. Собираем Docker-образ и перезапускаем контейнер через SSH
     - name: Docker Compose up
       uses: appleboy/ssh-action@v1.0.0
+      env:
+        DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        DOCKERHUB_TOKEN:   ${{ secrets.DOCKERHUB_TOKEN }}
       # передаём Hub-секреты внутрь SSH-сессии
       with:
         host:       ${{ secrets.VPS_HOST }}


### PR DESCRIPTION
## Summary
- pass DockerHub credentials to SSH action environment

## Testing
- `./gradlew test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68495d24bae48326b1b7abb884593ee6