### PR TITLE
Add events block to nginx config

### DIFF
--- a/infra/nginx/nginx.conf.template
+++ b/infra/nginx/nginx.conf.template
@@ -1,4 +1,4 @@
-worker_processes auto;
+worker_processes  1;
 
 events {
     worker_connections 1024;


### PR DESCRIPTION
## Summary
- set `worker_processes 1` in nginx template
- keep mandatory `events` block with `worker_connections`

## Testing
- `docker compose restart nginx` *(fails: `docker: command not found`)*
- `docker compose ps` *(fails: `docker: command not found`)*
- `curl -I http://localhost:8080` *(fails: couldn't connect)*

------
https://chatgpt.com/codex/tasks/task_e_684975520ee8832685caf5c7c7c9531b