### PR TITLE
Update deploy workflow to use SSH keys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,6 @@
 # Requires secrets:
-#   VPS_HOST, VPS_USER, VPS_PASSWORD
-#   (optional) VPS_PORT – если SSH-порт не 22
+#   VPS_HOST, VPS_USER, VPS_SSH_KEY
+#   (optional) VPS_SSH_PORT – если SSH-порт не 22
 
 name: Deploy to VPS
 
@@ -199,9 +199,8 @@ jobs:
       with:
         host:       ${{ secrets.VPS_HOST }}
         username:   ${{ secrets.VPS_USER }}
-        password:   ${{ secrets.VPS_PASSWORD }}
-        # 🛑 Если ваш SSH-порт – не 22, раскомментируйте строку ниже:
-        # port:     ${{ secrets.VPS_PORT }}
+        key:        ${{ secrets.VPS_SSH_KEY }}
+        port:       ${{ secrets.VPS_SSH_PORT }}
         # Передаём на сервер не только Dockerfile и compose, но и исходники
         # бэкенда, чтобы Docker смог собрать jar внутри контейнера
         source: "backend,infra/docker-compose.yml,scripts/wait-for-db.sh,infra/nginx/nginx.conf,infra/prometheus/prometheus.yml"
@@ -214,8 +213,8 @@ jobs:
       with:
         host:       ${{ secrets.VPS_HOST }}
         username:   ${{ secrets.VPS_USER }}
-        password:   ${{ secrets.VPS_PASSWORD }}
-        # port:     ${{ secrets.VPS_PORT }}
+        key:        ${{ secrets.VPS_SSH_KEY }}
+        port:       ${{ secrets.VPS_SSH_PORT }}
         envs: DEPLOY_DIR
         script: |
           mkdir -p "$HOME/$DEPLOY_DIR"
@@ -226,7 +225,8 @@ jobs:
       with:
         host:       ${{ secrets.VPS_HOST }}
         username:   ${{ secrets.VPS_USER }}
-        password:   ${{ secrets.VPS_PASSWORD }}
+        key:        ${{ secrets.VPS_SSH_KEY }}
+        port:       ${{ secrets.VPS_SSH_PORT }}
         target: ${{ env.DEPLOY_DIR }}/infra
         source: infra/.env
 
@@ -254,8 +254,8 @@ jobs:
       with:
         host:       ${{ secrets.VPS_HOST }}
         username:   ${{ secrets.VPS_USER }}
-        password:   ${{ secrets.VPS_PASSWORD }}
-        # port:     ${{ secrets.VPS_PORT }}
+        key:        ${{ secrets.VPS_SSH_KEY }}
+        port:       ${{ secrets.VPS_SSH_PORT }}
         envs: DEPLOY_DIR,DB_HOST,DB_PORT,DB_USER,DB_PASSWORD,DB_NAME,SMTP_HOST,SMTP_PORT,SMTP_USERNAME,SMTP_PASSWORD,SMTP_AUTH,SMTP_STARTTLS,MAIL_FROM,TELEGRAM_BOT_TOKEN,JWT_SECRET,NGINX_HTTP_PORT,NGINX_HTTPS_PORT
         script: |
           mkdir -p "$HOME/$DEPLOY_DIR/infra"
@@ -283,8 +283,8 @@ jobs:
       with:
         host:       ${{ secrets.VPS_HOST }}
         username:   ${{ secrets.VPS_USER }}
-        password:   ${{ secrets.VPS_PASSWORD }}
-        # port:   ${{ secrets.VPS_PORT }}
+        key:        ${{ secrets.VPS_SSH_KEY }}
+        port:       ${{ secrets.VPS_SSH_PORT }}
         script: |
           sudo systemctl stop nginx || true
 
@@ -299,8 +299,8 @@ jobs:
       with:
         host:       ${{ secrets.VPS_HOST }}
         username:   ${{ secrets.VPS_USER }}
-        password:   ${{ secrets.VPS_PASSWORD }}
-        # port:     ${{ secrets.VPS_PORT }}
+        key:        ${{ secrets.VPS_SSH_KEY }}
+        port:       ${{ secrets.VPS_SSH_PORT }}
         envs: DEPLOY_DIR,DOCKERHUB_USERNAME,DOCKERHUB_TOKEN
         script: |
           #---- Docker Hub login, чтобы не ловить 429


### PR DESCRIPTION
## Summary
- use key-based authentication in deploy workflow

## Testing
- `npm ci`
- `cd frontend && npm ci`
- `npm run lint`
- `npm run lint:fix`
- `./backend/gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_684984d7096483269fe24b83e7bc19e3