### PR TITLE
Add nginx smoke test workflow

### DIFF
--- a/.github/workflows/nginx-smoke-test.yml
+++ b/.github/workflows/nginx-smoke-test.yml
@@ -1,0 +1,45 @@
+name: Smokescreen Nginx Build
+
+on:
+  push:
+    paths:
+      - 'infra/nginx/**'
+      - '.github/workflows/nginx-smoke-test.yml'
+
+jobs:
+  build-and-test-nginx:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
+      - name: Build Nginx image
+        run: |
+          docker build \
+            --cache-from=type=local,src=/tmp/.buildx-cache \
+            --cache-to=type=local,dest=/tmp/.buildx-cache-new \
+            -t schedule-app-nginx-test \
+            infra/nginx
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+      - name: Test generated Nginx config
+        run: |
+          docker run --rm schedule-app-nginx-test nginx -t
+
+      - name: Smoke-start container & curl
+        run: |
+          docker run -d --name smoke-nginx -p 8081:80 schedule-app-nginx-test
+          sleep 3
+          curl -f http://localhost:8081 || (docker logs smoke-nginx && exit 1)
+        
+      - run: docker rm -f smoke-nginx

--- a/docs/NGINX_DEPLOYMENT.md
+++ b/docs/NGINX_DEPLOYMENT.md
@@ -7,6 +7,8 @@ Configuration lives in the `nginx/` directory of the main repository. All change
 
 ## CI Validation
 GitHub Actions renders `nginx.conf` from `nginx.conf.template` using environment variables and runs `nginx -t` inside the official container. The workflow fails if the syntax is invalid.
+The `nginx-smoke-test.yml` workflow additionally builds the image and starts it
+on a temporary port, performing a simple `curl` request to catch runtime issues.
 
 At runtime the container executes `/docker-entrypoint.sh`. This script substitutes `$APP_HOST`, `$APP_PORT` and `$SERVER_NAME` into `nginx.conf.template` using `envsubst` and then launches NGINX in the foreground. This allows the same image to be reused across environments.
 


### PR DESCRIPTION
## Summary
- add GitHub Action for nginx smoke testing
- document the new smoke test in deployment docs

## Testing
- `./backend/gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6849d97fa3a08326a7595e2a94ef2f68