### PR TITLE
Add Kubernetes design doc

### DIFF
--- a/docs/KUBERNETES_DESIGN.md
+++ b/docs/KUBERNETES_DESIGN.md
@@ -1,0 +1,54 @@
+# Kubernetes Design
+
+This document defines the target architecture and technology stack for running
+Schedule Tracker under Kubernetes. The goal is to migrate from Docker Compose
+while keeping the deployment maintainable for the next 12–18 months.
+
+## Goals
+
+- Build container images for all components.
+- Deploy the application to a Kubernetes cluster using Helm.
+- Provide observability and basic automation from day one.
+
+## Target stack
+
+- **Kubernetes 1.30+** with containerd runtime.
+- **Helm** for packaging manifests; charts live in `infra/k8s/helm`.
+- **NGINX Ingress Controller** for external access.
+- **PostgreSQL** as a StatefulSet or managed DB service.
+- **RabbitMQ** for background tasks and notifications.
+- **Prometheus** and **Grafana** for metrics.
+- **Loki** for log aggregation.
+- **Jaeger** and **OpenTelemetry** for tracing.
+- **GitHub Actions** to build OCI images and run `helm upgrade --install`.
+
+## Services
+
+- `backend` &ndash; Spring Boot API packaged as a Docker image.
+- `frontend` &ndash; React SPA served via NGINX or the ingress controller.
+- `rabbitmq` &ndash; message broker for asynchronous workflows.
+- `postgresql` &ndash; primary data store.
+
+## Deployment model
+
+1. CI builds images using the existing Dockerfiles.
+2. Charts render environment-specific values (staging, prod).
+3. `helm upgrade --install` deploys to the cluster.
+4. Horizontal Pod Autoscaler scales the backend based on CPU usage.
+
+Configuration is passed through environment variables in `values.yaml` and
+mounted Secrets. Persistent data for Postgres and RabbitMQ resides on
+ProvisionedVolumes.
+
+## Observability
+
+Prometheus scrapes metrics from the application and infrastructure. Grafana
+presents dashboards. OpenTelemetry agents send traces to Jaeger. Logs are
+collected via Fluent Bit and stored in Loki for easy querying.
+
+## Mid‑term outlook
+
+The first milestone is running the monolith on Kubernetes with automated
+builds and releases. Once stable we will evaluate extracting separate services
+and adopting a service mesh for traffic management. The stack above remains the
+baseline for at least the next year.

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ This directory contains all NGINX related documents. Each file focuses on a spec
 - `DNS_SETUP.md` – required DNS records for production deployment.
 - `SMTP_CONFIGURATION.md` – environment variables for outgoing email
 - `LETS_ENCRYPT.md` – obtaining trusted TLS certificates
+- `KUBERNETES_DESIGN.md` – migration plan and target stack
 - `../infra/dns` – BIND zone files reflecting the recommended records.
 
 Documentation is reviewed **quarterly**. The SRE Lead tracks outdated sections and opens issues for updates.


### PR DESCRIPTION
## Summary
- document baseline Kubernetes architecture and stack
- link to the new design doc from docs/README

## Testing
- `./gradlew test`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a04ad2b588326873aaa54f2e1d730