### PR TITLE
Add Secret-based credentials to Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 - `backend/` — серверная часть и REST API
 - `frontend/` — клиентское приложение Vite/React
-- `infra/` — Docker Compose и конфигурация NGINX
+- `infra/` — Docker Compose, Helm charts и конфигурация NGINX
 - `docs/` — документация и ADR. Также в каталоге находится файл
   `ARCHITECTURE_IMPROVEMENTS.md` с планом дальнейшего развития
   инфраструктуры и рекомендациями по запуску

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -17,6 +17,10 @@ development.
 | `POSTGRES_DB` | `schedule` | `infra/docker-compose.yml` | `infra/.env` |
 | `POSTGRES_USER` | `postgres` | `infra/docker-compose.yml` | `infra/.env` |
 | `POSTGRES_PASSWORD` | `postgres` | `infra/docker-compose.yml` | `infra/.env` |
+| `RABBITMQ_HOST` | `rabbitmq` | `infra/k8s/helm/schedule-app/templates/backend-deployment.yaml` | chart values |
+| `RABBITMQ_PORT` | `5672` | `infra/k8s/helm/schedule-app/templates/backend-deployment.yaml` | chart values |
+| `RABBITMQ_USER` | `user` | `infra/k8s/helm/schedule-app/templates/rabbitmq-statefulset.yaml` | chart values |
+| `RABBITMQ_PASSWORD` | `secret` | `infra/k8s/helm/schedule-app/templates/rabbitmq-statefulset.yaml` | chart values |
 | `SMTP_HOST` | `smtp.example.com` | `backend/src/main/resources/application.yml` | `infra/.env` or secrets |
 | `SMTP_PORT` | `587` | `backend/src/main/resources/application.yml` | `infra/.env` or secrets |
 | `SMTP_USERNAME` | `user@example.com` | `backend/src/main/resources/application.yml` | `infra/.env` or secrets |

--- a/docs/KUBERNETES_DESIGN.md
+++ b/docs/KUBERNETES_DESIGN.md
@@ -40,6 +40,10 @@ Configuration is passed through environment variables in `values.yaml` and
 mounted Secrets. Persistent data for Postgres and RabbitMQ resides on
 ProvisionedVolumes.
 
+An initial Helm chart named `schedule-app` lives in
+`infra/k8s/helm/schedule-app` and deploys the monolith together with a
+PostgreSQL database and RabbitMQ broker.
+
 ## Observability
 
 Prometheus scrapes metrics from the application and infrastructure. Grafana

--- a/infra/k8s/helm/README.md
+++ b/infra/k8s/helm/README.md
@@ -1,3 +1,10 @@
 # Helm charts
 
-Kubernetes manifests for the application are packaged here. GitHub Actions renders values and deploys them to the k3s cluster using `helm upgrade --install`.
+This directory contains Helm charts for deploying the project to Kubernetes. The
+`deploy.yml` workflow in GitHub Actions renders environment specific values and
+runs `helm upgrade --install` against the target cluster.
+
+Available charts:
+
+- `schedule-app` – monolithic application with PostgreSQL, RabbitMQ and an ingress rule.
+

--- a/infra/k8s/helm/schedule-app/Chart.yaml
+++ b/infra/k8s/helm/schedule-app/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: schedule-app
+description: Helm chart for Schedule Tracker
+version: 0.1.0
+appVersion: "1.0"
+type: application
+

--- a/infra/k8s/helm/schedule-app/README.md
+++ b/infra/k8s/helm/schedule-app/README.md
@@ -1,0 +1,29 @@
+# schedule-app Helm Chart
+
+This chart deploys the monolithic Schedule Tracker application together with a PostgreSQL database and RabbitMQ instance.
+It targets Kubernetes clusters running version 1.30 or newer and follows the design outlined in
+[../../../../docs/KUBERNETES_DESIGN.md](../../../../docs/KUBERNETES_DESIGN.md).
+
+The chart defines:
+
+- `Deployment` and `Service` for the Spring Boot backend
+- `StatefulSet` and `Service` for PostgreSQL
+- `StatefulSet` and `Service` for RabbitMQ
+- `Ingress` resource configured for the NGINX Ingress Controller
+  - `HorizontalPodAutoscaler` for scaling the backend
+
+Values controlling credentials:
+
+- `postgresql.username` / `postgresql.password`
+- `rabbitmq.username` / `rabbitmq.password`
+- `jwtSecret` used by the backend
+
+Default values assume a demo environment. Sensitive strings like database and
+RabbitMQ passwords are stored in a `Secret` generated from `values.yaml`.
+Adjust the container images and credentials before deploying to production:
+
+```bash
+helm upgrade --install schedule-app infra/k8s/helm/schedule-app \
+  --values infra/k8s/helm/schedule-app/values.yaml
+```
+

--- a/infra/k8s/helm/schedule-app/templates/_helpers.tpl
+++ b/infra/k8s/helm/schedule-app/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "schedule-app.fullname" -}}
+{{- printf "%s" .Release.Name -}}
+{{- end -}}

--- a/infra/k8s/helm/schedule-app/templates/backend-deployment.yaml
+++ b/infra/k8s/helm/schedule-app/templates/backend-deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "schedule-app.fullname" . }}-backend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "schedule-app.fullname" . }}-backend
+  template:
+    metadata:
+      labels:
+        app: {{ include "schedule-app.fullname" . }}-backend
+    spec:
+      containers:
+        - name: backend
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 8080
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: postgres
+            - name: DB_HOST
+              value: {{ include "schedule-app.fullname" . }}-postgresql
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_NAME
+              value: {{ .Values.postgresql.database }}
+            - name: DB_USER
+              value: {{ .Values.postgresql.username }}
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "schedule-app.fullname" . }}
+                  key: postgres-password
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "schedule-app.fullname" . }}
+                  key: jwt-secret
+            - name: RABBITMQ_HOST
+              value: {{ include "schedule-app.fullname" . }}-rabbitmq
+            - name: RABBITMQ_PORT
+              value: "5672"
+            - name: RABBITMQ_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "schedule-app.fullname" . }}
+                  key: rabbitmq-user
+            - name: RABBITMQ_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "schedule-app.fullname" . }}
+                  key: rabbitmq-password
+

--- a/infra/k8s/helm/schedule-app/templates/backend-service.yaml
+++ b/infra/k8s/helm/schedule-app/templates/backend-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "schedule-app.fullname" . }}-backend
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ include "schedule-app.fullname" . }}-backend
+

--- a/infra/k8s/helm/schedule-app/templates/hpa.yaml
+++ b/infra/k8s/helm/schedule-app/templates/hpa.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "schedule-app.fullname" . }}-backend
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "schedule-app.fullname" . }}-backend
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+

--- a/infra/k8s/helm/schedule-app/templates/ingress.yaml
+++ b/infra/k8s/helm/schedule-app/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "schedule-app.fullname" . }}
+  {{- if .Values.ingress.className }}
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.className }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . }}
+        {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+  {{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "schedule-app.fullname" $ }}-backend
+                port:
+                  number: {{ $.Values.service.port }}
+        {{- end }}
+  {{- end }}
+{{- end }}
+

--- a/infra/k8s/helm/schedule-app/templates/postgresql-service.yaml
+++ b/infra/k8s/helm/schedule-app/templates/postgresql-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "schedule-app.fullname" . }}-postgresql
+spec:
+  ports:
+    - port: 5432
+      targetPort: 5432
+  selector:
+    app: {{ include "schedule-app.fullname" . }}-postgresql
+

--- a/infra/k8s/helm/schedule-app/templates/postgresql-statefulset.yaml
+++ b/infra/k8s/helm/schedule-app/templates/postgresql-statefulset.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "schedule-app.fullname" . }}-postgresql
+spec:
+  serviceName: {{ include "schedule-app.fullname" . }}-postgresql
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "schedule-app.fullname" . }}-postgresql
+  template:
+    metadata:
+      labels:
+        app: {{ include "schedule-app.fullname" . }}-postgresql
+    spec:
+      containers:
+        - name: postgres
+          image: {{ .Values.postgresql.image }}
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.postgresql.database }}
+            - name: POSTGRES_USER
+              value: {{ .Values.postgresql.username }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "schedule-app.fullname" . }}
+                  key: postgres-password
+          volumeMounts:
+            - mountPath: /var/lib/postgresql/data
+              name: data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: {{ .Values.postgresql.persistence.size }}
+

--- a/infra/k8s/helm/schedule-app/templates/rabbitmq-service.yaml
+++ b/infra/k8s/helm/schedule-app/templates/rabbitmq-service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "schedule-app.fullname" . }}-rabbitmq
+spec:
+  ports:
+    - port: 5672
+      targetPort: 5672
+  selector:
+    app: {{ include "schedule-app.fullname" . }}-rabbitmq

--- a/infra/k8s/helm/schedule-app/templates/rabbitmq-statefulset.yaml
+++ b/infra/k8s/helm/schedule-app/templates/rabbitmq-statefulset.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "schedule-app.fullname" . }}-rabbitmq
+spec:
+  serviceName: {{ include "schedule-app.fullname" . }}-rabbitmq
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "schedule-app.fullname" . }}-rabbitmq
+  template:
+    metadata:
+      labels:
+        app: {{ include "schedule-app.fullname" . }}-rabbitmq
+    spec:
+      containers:
+        - name: rabbitmq
+          image: {{ .Values.rabbitmq.image }}
+          ports:
+            - containerPort: 5672
+          env:
+            - name: RABBITMQ_DEFAULT_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "schedule-app.fullname" . }}
+                  key: rabbitmq-user
+            - name: RABBITMQ_DEFAULT_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "schedule-app.fullname" . }}
+                  key: rabbitmq-password
+          volumeMounts:
+            - mountPath: /var/lib/rabbitmq
+              name: data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: {{ .Values.rabbitmq.persistence.size }}
+

--- a/infra/k8s/helm/schedule-app/templates/secret.yaml
+++ b/infra/k8s/helm/schedule-app/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "schedule-app.fullname" . }}
+type: Opaque
+stringData:
+  postgres-password: {{ .Values.postgresql.password }}
+  rabbitmq-user: {{ .Values.rabbitmq.username }}
+  rabbitmq-password: {{ .Values.rabbitmq.password }}
+  jwt-secret: {{ .Values.jwtSecret }}

--- a/infra/k8s/helm/schedule-app/values.yaml
+++ b/infra/k8s/helm/schedule-app/values.yaml
@@ -1,0 +1,37 @@
+image:
+  repository: schedule-backend
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: schedule.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+postgresql:
+  image: postgres:16.2-alpine
+  persistence:
+    enabled: true
+    size: 1Gi
+  database: schedule
+  username: postgres
+  password: postgres
+
+jwtSecret: secret
+
+rabbitmq:
+  image: rabbitmq:3.13-management
+  username: user
+  password: password
+  persistence:
+    enabled: true
+    size: 1Gi


### PR DESCRIPTION
## Summary
- store Postgres, RabbitMQ and JWT credentials in a Kubernetes Secret
- reference the Secret from deployments and statefulsets
- document new RabbitMQ environment variables

## Testing
- `./backend/gradlew -p backend test`
- `npm ci`
- `npm ci --prefix frontend`
- `npm run lint --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_684a067a59f083269eab65ef4a4e6340