### PR TITLE
Improve Helm chart configuration flexibility

### DIFF
--- a/infra/k8s/helm/schedule-app/README.md
+++ b/infra/k8s/helm/schedule-app/README.md
@@ -12,10 +12,16 @@ The chart defines:
 - `Ingress` resource configured for the NGINX Ingress Controller
   - `HorizontalPodAutoscaler` for scaling the backend
 
-Values controlling credentials:
+Values controlling credentials and connectivity:
 
+- `postgresql.enabled` – set to `false` to use an external database
+- `postgresql.host` / `postgresql.port`
 - `postgresql.username` / `postgresql.password`
+- `rabbitmq.enabled` – set to `false` to use an external broker
+- `rabbitmq.host` / `rabbitmq.port`
 - `rabbitmq.username` / `rabbitmq.password`
+- `replicaCount` to set the default number of backend pods
+- `autoscaling.*` to tune or disable the Horizontal Pod Autoscaler
 - `jwtSecret` used by the backend
 - `resources` for the backend container requests and limits
 

--- a/infra/k8s/helm/schedule-app/templates/backend-deployment.yaml
+++ b/infra/k8s/helm/schedule-app/templates/backend-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: {{ include "schedule-app.fullname" . }}-backend
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       app: {{ include "schedule-app.fullname" . }}-backend
@@ -36,13 +36,13 @@ spec:
             - name: SPRING_PROFILES_ACTIVE
               value: postgres
             - name: DB_HOST
-              value: {{ include "schedule-app.fullname" . }}-postgresql
+              value: {{- if .Values.postgresql.enabled }}{{ include "schedule-app.fullname" . }}-postgresql{{- else }}{{ .Values.postgresql.host | quote }}{{- end }}
             - name: DB_PORT
-              value: "5432"
+              value: {{ .Values.postgresql.port | quote }}
             - name: DB_NAME
-              value: {{ .Values.postgresql.database }}
+              value: {{ .Values.postgresql.database | quote }}
             - name: DB_USER
-              value: {{ .Values.postgresql.username }}
+              value: {{ .Values.postgresql.username | quote }}
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -54,9 +54,9 @@ spec:
                   name: {{ include "schedule-app.fullname" . }}
                   key: jwt-secret
             - name: RABBITMQ_HOST
-              value: {{ include "schedule-app.fullname" . }}-rabbitmq
+              value: {{- if .Values.rabbitmq.enabled }}{{ include "schedule-app.fullname" . }}-rabbitmq{{- else }}{{ .Values.rabbitmq.host | quote }}{{- end }}
             - name: RABBITMQ_PORT
-              value: "5672"
+              value: {{ .Values.rabbitmq.port | quote }}
             - name: RABBITMQ_USER
               valueFrom:
                 secretKeyRef:

--- a/infra/k8s/helm/schedule-app/templates/hpa.yaml
+++ b/infra/k8s/helm/schedule-app/templates/hpa.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -7,13 +8,14 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: {{ include "schedule-app.fullname" . }}-backend
-  minReplicas: 1
-  maxReplicas: 5
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 80
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}
 

--- a/infra/k8s/helm/schedule-app/templates/postgresql-service.yaml
+++ b/infra/k8s/helm/schedule-app/templates/postgresql-service.yaml
@@ -1,11 +1,13 @@
+{{- if .Values.postgresql.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "schedule-app.fullname" . }}-postgresql
 spec:
   ports:
-    - port: 5432
-      targetPort: 5432
+    - port: {{ .Values.postgresql.port }}
+      targetPort: {{ .Values.postgresql.port }}
   selector:
     app: {{ include "schedule-app.fullname" . }}-postgresql
+{{- end }}
 

--- a/infra/k8s/helm/schedule-app/templates/postgresql-statefulset.yaml
+++ b/infra/k8s/helm/schedule-app/templates/postgresql-statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.postgresql.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -17,7 +18,7 @@ spec:
         - name: postgres
           image: {{ .Values.postgresql.image }}
           ports:
-            - containerPort: 5432
+            - containerPort: {{ .Values.postgresql.port }}
           env:
             - name: POSTGRES_DB
               value: {{ .Values.postgresql.database }}
@@ -39,4 +40,5 @@ spec:
         resources:
           requests:
             storage: {{ .Values.postgresql.persistence.size }}
+{{- end }}
 

--- a/infra/k8s/helm/schedule-app/templates/rabbitmq-service.yaml
+++ b/infra/k8s/helm/schedule-app/templates/rabbitmq-service.yaml
@@ -1,10 +1,12 @@
+{{- if .Values.rabbitmq.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "schedule-app.fullname" . }}-rabbitmq
 spec:
   ports:
-    - port: 5672
-      targetPort: 5672
+    - port: {{ .Values.rabbitmq.port }}
+      targetPort: {{ .Values.rabbitmq.port }}
   selector:
     app: {{ include "schedule-app.fullname" . }}-rabbitmq
+{{- end }}

--- a/infra/k8s/helm/schedule-app/templates/rabbitmq-statefulset.yaml
+++ b/infra/k8s/helm/schedule-app/templates/rabbitmq-statefulset.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rabbitmq.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -17,7 +18,7 @@ spec:
         - name: rabbitmq
           image: {{ .Values.rabbitmq.image }}
           ports:
-            - containerPort: 5672
+            - containerPort: {{ .Values.rabbitmq.port }}
           env:
             - name: RABBITMQ_DEFAULT_USER
               valueFrom:
@@ -40,4 +41,5 @@ spec:
         resources:
           requests:
             storage: {{ .Values.rabbitmq.persistence.size }}
+{{- end }}
 

--- a/infra/k8s/helm/schedule-app/values.yaml
+++ b/infra/k8s/helm/schedule-app/values.yaml
@@ -3,6 +3,14 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 
+replicaCount: 1
+
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+
 resources:
   requests:
     memory: "256Mi"
@@ -26,6 +34,9 @@ ingress:
   tls: []
 
 postgresql:
+  enabled: true
+  host: postgresql
+  port: 5432
   image: postgres:16.2-alpine
   persistence:
     enabled: true
@@ -37,6 +48,9 @@ postgresql:
 jwtSecret: secret
 
 rabbitmq:
+  enabled: true
+  host: rabbitmq
+  port: 5672
   image: rabbitmq:3.13-management
   username: user
   password: password


### PR DESCRIPTION
## Summary
- allow setting backend `replicaCount`
- make HPA configurable via `autoscaling` values
- quote DB and RabbitMQ parameters in deployment
- document the new values in the chart README

## Testing
- `./gradlew test`
- `npm ci`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a103f4b148326b4a0cad3db2bb373