### PR TITLE
Refine Helm migrations

### DIFF
--- a/.github/workflows/deploy-k8s.yml
+++ b/.github/workflows/deploy-k8s.yml
@@ -67,4 +67,5 @@ jobs:
           helm upgrade --install schedule-app infra/k8s/helm/schedule-app \
             --set image.repository=${{ secrets.DOCKER_REPOSITORY }}/schedule-backend \
             --set image.tag=${GITHUB_SHA} \
-            --kubeconfig kubeconfig
+            --kubeconfig kubeconfig \
+            --atomic --wait --timeout 5m

--- a/README.md
+++ b/README.md
@@ -170,11 +170,15 @@ docker ps -aq --filter "label=com.docker.compose.project=infra" | xargs -r docke
 
 ### Kubernetes Deployment
 Helm charts for the application reside in `infra/k8s/helm`. Use the
-`deploy-k8s.yml` workflow or run `helm upgrade --install` manually:
+`deploy-k8s.yml` workflow or run `helm upgrade --install` manually.
+Before each upgrade a Helm hook launches a short-lived Job to apply
+database migrations so the backend starts with the correct schema. The Job
+waits for the database via `wait-for-db.sh` and is removed once completed:
 
 ```bash
 helm upgrade --install schedule-app infra/k8s/helm/schedule-app \
-  --values infra/k8s/helm/schedule-app/values.yaml
+  --values infra/k8s/helm/schedule-app/values.yaml \
+  --atomic --wait --timeout 5m
 ```
 The cluster credentials must be provided in `KUBE_CONFIG_B64` and Docker images
 are pulled from the registry defined by `DOCKER_REPOSITORY`.

--- a/docs/KUBERNETES_DEPLOYMENT.md
+++ b/docs/KUBERNETES_DEPLOYMENT.md
@@ -10,7 +10,7 @@ The pipeline builds Docker images, pushes them to a registry and runs `helm upgr
 2. On each push to `main` it builds the backend image using the provided Dockerfile.
 3. The image is tagged with the commit SHA and uploaded to the registry defined by `DOCKER_REPOSITORY`.
 4. Helm is configured using the kubeconfig stored in `KUBE_CONFIG_B64`.
-5. `helm upgrade --install` renders the chart from `infra/k8s/helm/schedule-app` with the new image tag.
+5. `helm upgrade --install` renders the chart from `infra/k8s/helm/schedule-app` with the new image tag. The command runs with `--atomic` and waits up to five minutes for rollout completion.
 
 ## Required secrets
 
@@ -19,3 +19,4 @@ The pipeline builds Docker images, pushes them to a registry and runs `helm upgr
 
 Adjust values in `infra/k8s/helm/schedule-app/values.yaml` for production before running the workflow.
 Set appropriate CPU and memory limits under the `resources` key so pods are scheduled with reserved capacity.
+A `Job` named `schedule-app-migrate` runs as a Helm hook before each installation or upgrade to apply database migrations. The job waits for the database and is cleaned up automatically after success.

--- a/docs/KUBERNETES_DESIGN.md
+++ b/docs/KUBERNETES_DESIGN.md
@@ -42,7 +42,10 @@ ProvisionedVolumes.
 
 An initial Helm chart named `schedule-app` lives in
 `infra/k8s/helm/schedule-app` and deploys the monolith together with a
-PostgreSQL database and RabbitMQ broker.
+PostgreSQL database and RabbitMQ broker. Database migrations are executed by a
+`pre-install`/`pre-upgrade` Helm hook that waits for the database using the
+`wait-for-db.sh` script. Completed migration Jobs are deleted automatically so
+they do not clutter the namespace.
 
 ## Observability
 

--- a/infra/k8s/helm/README.md
+++ b/infra/k8s/helm/README.md
@@ -6,5 +6,5 @@ runs `helm upgrade --install` against the target cluster.
 
 Available charts:
 
-- `schedule-app` – monolithic application with PostgreSQL, RabbitMQ and an ingress rule.
+- `schedule-app` – monolithic application with PostgreSQL, RabbitMQ and an ingress rule. Database migrations run as a Helm hook before each upgrade. The migration job waits for the database and is deleted after completion.
 

--- a/infra/k8s/helm/schedule-app/README.md
+++ b/infra/k8s/helm/schedule-app/README.md
@@ -26,6 +26,9 @@ Values controlling credentials and connectivity:
 - `pdb.*` for the PodDisruptionBudget
 - `jwtSecret` used by the backend
 - `resources` for the backend container requests and limits
+- `migrations.enabled` to run Flyway migrations via a pre-install and pre-upgrade Job
+
+When `migrations.enabled` is `true`, a short-lived Job waits for the database using `wait-for-db.sh`, applies migrations and is removed automatically after completion.
 
 Default values assume a demo environment. Sensitive strings like database and
 RabbitMQ passwords are stored in a `Secret` generated from `values.yaml`.

--- a/infra/k8s/helm/schedule-app/templates/migration-job.yaml
+++ b/infra/k8s/helm/schedule-app/templates/migration-job.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.migrations.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "schedule-app.fullname" . }}-migrate
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      ttlSecondsAfterFinished: 120
+      containers:
+        - name: migrate
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/wait-for-db.sh", "java", "-jar", "/app/app.jar", "--spring.main.web-application-type=none"]
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: postgres
+            - name: DB_HOST
+              value: {{ if .Values.postgresql.enabled }}{{ include "schedule-app.fullname" . }}-postgresql{{ else }}{{ .Values.postgresql.host | quote }}{{- end }}
+            - name: DB_PORT
+              value: {{ .Values.postgresql.port | quote }}
+            - name: DB_NAME
+              value: {{ .Values.postgresql.database | quote }}
+            - name: DB_USER
+              value: {{ .Values.postgresql.username | quote }}
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "schedule-app.fullname" . }}
+                  key: postgres-password
+{{- end }}

--- a/infra/k8s/helm/schedule-app/values.yaml
+++ b/infra/k8s/helm/schedule-app/values.yaml
@@ -64,3 +64,6 @@ serviceMonitor:
 pdb:
   enabled: true
   minAvailable: 1
+
+migrations:
+  enabled: true


### PR DESCRIPTION
## Summary
- clean up migration job after success and wait for DB
- use `wait-for-db.sh` in the migration hook
- deploy workflow runs `helm upgrade` with `--atomic`
- document the enhanced migration step

## Testing
- `./gradlew test`
- `npm run lint --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_684a16c4d98c8326a30ec8e63fb35224