### PR TITLE
Add database backup CronJob to Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,3 +352,7 @@ scripts/backup-db.sh
 0 3 * * * /path/to/repo/scripts/backup-db.sh
 ```
 
+Under Kubernetes the Helm chart can enable an automated CronJob that runs the
+same script nightly. Dumps are stored on a PersistentVolume and rotated
+externally.
+

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,7 +18,8 @@ WORKDIR /app
 COPY --from=build /workspace/backend/app.jar app.jar
 # Скрипт ожидания доступности базы данных
 COPY scripts/wait-for-db.sh /wait-for-db.sh
-RUN chmod +x /wait-for-db.sh
+COPY scripts/backup-db.sh /backup-db.sh
+RUN chmod +x /wait-for-db.sh /backup-db.sh
 # Приложение использует переменные `DB_HOST` и `DB_PORT` для подключения к БД.
 # Задайте их при запуске контейнера.
 EXPOSE 8080

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -44,7 +44,7 @@ defaults (`8080` and `8443`) conflict with other services on the host. `NGINX_LO
 | `PROXY_PORT` | `8080` | `scripts/setup-proxy.sh`, `.github/workflows/deploy.yml` | secrets or shell |
 | `HTTP_PROXY` | `http://proxy.example.com:8080` | `scripts/setup-proxy.sh` | shell |
 | `HTTPS_PROXY` | `http://proxy.example.com:8080` | `scripts/setup-proxy.sh` | shell |
-| `BACKUP_DIR` | `backups` | `scripts/backup-db.sh` | shell |
+| `BACKUP_DIR` | `backups` | `scripts/backup-db.sh`, `infra/k8s/helm/schedule-app/templates/backup-cronjob.yaml` | shell |
 | `VITE_API_URL` |  | `frontend/src/api.ts` | `frontend/.env` |
 | `DEPLOY_DIR` | `myapp` | `.github/workflows/deploy.yml` | workflow env |
 | `VPS_HOST` | `203.0.113.1` | `.github/workflows/deploy.yml` | secrets |

--- a/docs/KUBERNETES_DEPLOYMENT.md
+++ b/docs/KUBERNETES_DEPLOYMENT.md
@@ -20,3 +20,4 @@ The pipeline builds Docker images, pushes them to a registry and runs `helm upgr
 Adjust values in `infra/k8s/helm/schedule-app/values.yaml` for production before running the workflow.
 Set appropriate CPU and memory limits under the `resources` key so pods are scheduled with reserved capacity.
 A `Job` named `schedule-app-migrate` runs as a Helm hook before each installation or upgrade to apply database migrations. The job waits for the database and is cleaned up automatically after success.
+When `backup.enabled` is true the chart also provisions a `CronJob` that dumps the database every night using `pg_dump`.

--- a/docs/KUBERNETES_DESIGN.md
+++ b/docs/KUBERNETES_DESIGN.md
@@ -47,6 +47,10 @@ PostgreSQL database and RabbitMQ broker. Database migrations are executed by a
 `wait-for-db.sh` script. Completed migration Jobs are deleted automatically so
 they do not clutter the namespace.
 
+To protect data, a CronJob periodically executes `/backup-db.sh`. It dumps the
+database to a PersistentVolume mounted at `/backups`. The job is disabled by
+default and can be enabled via chart values.
+
 ## Observability
 
 Prometheus scrapes metrics from the application and infrastructure. Grafana

--- a/infra/k8s/helm/README.md
+++ b/infra/k8s/helm/README.md
@@ -6,5 +6,5 @@ runs `helm upgrade --install` against the target cluster.
 
 Available charts:
 
-- `schedule-app` – monolithic application with PostgreSQL, RabbitMQ and an ingress rule. Database migrations run as a Helm hook before each upgrade. The migration job waits for the database and is deleted after completion.
+- `schedule-app` – monolithic application with PostgreSQL, RabbitMQ and an ingress rule. Database migrations run as a Helm hook before each upgrade. The migration job waits for the database and is deleted after completion. Optional CronJob performs daily database backups when enabled.
 

--- a/infra/k8s/helm/schedule-app/README.md
+++ b/infra/k8s/helm/schedule-app/README.md
@@ -11,6 +11,7 @@ The chart defines:
 - `StatefulSet` and `Service` for RabbitMQ
 - `Ingress` resource configured for the NGINX Ingress Controller
   - `HorizontalPodAutoscaler` for scaling the backend
+- `CronJob` for periodic database backups
 
 Values controlling credentials and connectivity:
 
@@ -27,6 +28,9 @@ Values controlling credentials and connectivity:
 - `jwtSecret` used by the backend
 - `resources` for the backend container requests and limits
 - `migrations.enabled` to run Flyway migrations via a pre-install and pre-upgrade Job
+- `backup.enabled` to schedule periodic `pg_dump` backups via a CronJob
+- `backup.schedule` CRON expression defining when the backup runs
+- `backup.persistence.size` size of the PVC storing dumps
 
 When `migrations.enabled` is `true`, a short-lived Job waits for the database using `wait-for-db.sh`, applies migrations and is removed automatically after completion.
 

--- a/infra/k8s/helm/schedule-app/templates/backup-cronjob.yaml
+++ b/infra/k8s/helm/schedule-app/templates/backup-cronjob.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.backup.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "schedule-app.fullname" . }}-backup
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: backup
+              image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command: ["/backup-db.sh"]
+              env:
+                - name: DB_HOST
+                  value: {{ if .Values.postgresql.enabled }}{{ include "schedule-app.fullname" . }}-postgresql{{ else }}{{ .Values.postgresql.host | quote }}{{- end }}
+                - name: DB_PORT
+                  value: {{ .Values.postgresql.port | quote }}
+                - name: DB_NAME
+                  value: {{ .Values.postgresql.database | quote }}
+                - name: DB_USER
+                  value: {{ .Values.postgresql.username | quote }}
+                - name: DB_PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ include "schedule-app.fullname" . }}
+                      key: postgres-password
+                - name: BACKUP_DIR
+                  value: /backups
+              volumeMounts:
+                - name: backup
+                  mountPath: /backups
+          volumes:
+            - name: backup
+              persistentVolumeClaim:
+                claimName: {{ include "schedule-app.fullname" . }}-backup
+{{- end }}

--- a/infra/k8s/helm/schedule-app/templates/backup-pvc.yaml
+++ b/infra/k8s/helm/schedule-app/templates/backup-pvc.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.backup.enabled .Values.backup.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "schedule-app.fullname" . }}-backup
+spec:
+  accessModes: [ "ReadWriteOnce" ]
+  resources:
+    requests:
+      storage: {{ .Values.backup.persistence.size }}
+{{- end }}

--- a/infra/k8s/helm/schedule-app/values.yaml
+++ b/infra/k8s/helm/schedule-app/values.yaml
@@ -67,3 +67,10 @@ pdb:
 
 migrations:
   enabled: true
+
+backup:
+  enabled: false
+  schedule: "0 3 * * *"
+  persistence:
+    enabled: true
+    size: 1Gi


### PR DESCRIPTION
## Summary
- include `backup-db.sh` in backend container
- add CronJob and PVC templates for scheduled backups
- document backups in chart README and environment variables
- mention CronJob in Kubernetes docs and root README

## Testing
- `./backend/gradlew test`
- `npm ci && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a1bc7b5c88326a83704987cfb2a27