### PR TITLE
Add Kubernetes docs and make tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 COMPOSE_FILE ?= infra/docker-compose.yml
 
-.PHONY: build up down logs frontend
+.PHONY: build up down logs frontend k8s-deploy k8s-delete k8s-render
 
 build:
 	docker compose -f $(COMPOSE_FILE) build
@@ -9,10 +9,23 @@ up:
 	docker compose -f $(COMPOSE_FILE) up -d
 
 down:
-       docker compose -f infra/docker-compose.yml down --remove-orphans
+	docker compose -f infra/docker-compose.yml down --remove-orphans
 
 logs:
-        docker compose -f $(COMPOSE_FILE) logs -f
+	docker compose -f $(COMPOSE_FILE) logs -f
 
 frontend:
 	npm --prefix frontend run build
+
+k8s-deploy:
+	helm upgrade --install schedule-app infra/k8s/helm/schedule-app \
+		-f infra/k8s/helm/schedule-app/values.yaml \
+		--atomic --wait
+
+k8s-delete:
+	helm uninstall schedule-app || true
+
+k8s-render:
+	helm template schedule-app infra/k8s/helm/schedule-app \
+		-f infra/k8s/helm/schedule-app/values.yaml > rendered.yaml
+

--- a/README.md
+++ b/README.md
@@ -176,8 +176,12 @@ database migrations so the backend starts with the correct schema. The Job
 waits for the database via `wait-for-db.sh` and is removed once completed:
 
 ```bash
+make k8s-deploy
+```
+The command uses `values.yaml` by default. For a production setup run:
+```bash
 helm upgrade --install schedule-app infra/k8s/helm/schedule-app \
-  --values infra/k8s/helm/schedule-app/values.yaml \
+  --values infra/k8s/helm/schedule-app/values-production.yaml \
   --atomic --wait --timeout 5m
 ```
 The cluster credentials must be provided in `KUBE_CONFIG_B64` and Docker images

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,11 @@ This directory contains all NGINX related documents. Each file focuses on a spec
 - `NGINX_DEPLOYMENT.md` – CI/CD pipeline and delivery process.
 - `RUNBOOK_NGINX.md` – operational runbook for common incidents.
 - `SECURITY_CHECKLIST.md` – release checklist covering security controls.
+
+Additional files describe the Kubernetes migration:
+- `KUBERNETES_DESIGN.md` – target cluster architecture and stack.
+- `KUBERNETES_DEPLOYMENT.md` – CI workflow and Helm usage.
+- `RUNBOOK_K8S.md` – troubleshooting steps for the cluster.
 - `NGINX_TRAINING.md` – training materials for developers and SREs.
 - `DNS_SETUP.md` – required DNS records for production deployment.
 - `SMTP_CONFIGURATION.md` – environment variables for outgoing email

--- a/docs/RUNBOOK_K8S.md
+++ b/docs/RUNBOOK_K8S.md
@@ -1,0 +1,44 @@
+# Kubernetes Incident Runbook
+
+This document outlines common troubleshooting steps for running the application on a Kubernetes cluster.
+
+## Check Pod status
+1. List pods in the namespace:
+   ```bash
+   kubectl get pods -n schedule
+   ```
+2. Inspect a failing pod:
+   ```bash
+   kubectl describe pod <name> -n schedule
+   kubectl logs <name> -n schedule
+   ```
+
+## Verify database and RabbitMQ
+1. Ensure StatefulSets are healthy:
+   ```bash
+   kubectl get statefulsets -n schedule
+   ```
+2. Check persistent volumes:
+   ```bash
+   kubectl get pvc -n schedule
+   ```
+
+## Rolling back a release
+1. List Helm revisions:
+   ```bash
+   helm history schedule-app
+   ```
+2. Roll back to a previous revision:
+   ```bash
+   helm rollback schedule-app <revision>
+   ```
+
+## Cleaning up failed deployments
+1. Delete an unsuccessful release:
+   ```bash
+   helm uninstall schedule-app
+   ```
+2. Remove remaining Jobs and pods:
+   ```bash
+   kubectl delete jobs --selector=app.kubernetes.io/name=schedule-app -n schedule
+   ```

--- a/infra/k8s/helm/schedule-app/README.md
+++ b/infra/k8s/helm/schedule-app/README.md
@@ -36,10 +36,11 @@ When `migrations.enabled` is `true`, a short-lived Job waits for the database us
 
 Default values assume a demo environment. Sensitive strings like database and
 RabbitMQ passwords are stored in a `Secret` generated from `values.yaml`.
-Adjust the container images and credentials before deploying to production:
+Adjust the container images and credentials before deploying to production. A
+sample configuration is provided in `values-production.yaml`:
 
 ```bash
 helm upgrade --install schedule-app infra/k8s/helm/schedule-app \
-  --values infra/k8s/helm/schedule-app/values.yaml
+  --values infra/k8s/helm/schedule-app/values-production.yaml
 ```
 

--- a/infra/k8s/helm/schedule-app/values-production.yaml
+++ b/infra/k8s/helm/schedule-app/values-production.yaml
@@ -1,0 +1,79 @@
+image:
+  repository: schedule-backend
+  tag: latest
+  pullPolicy: IfNotPresent
+
+replicaCount: 3
+
+autoscaling:
+  enabled: true
+  minReplicas: 3
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 75
+
+resources:
+  requests:
+    memory: "512Mi"
+    cpu: "1"
+  limits:
+    memory: "1Gi"
+    cpu: "2"
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: schedule.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: schedule-tls
+      hosts:
+        - schedule.example.com
+
+postgresql:
+  enabled: true
+  host: postgresql
+  port: 5432
+  image: postgres:16.2-alpine
+  persistence:
+    enabled: true
+    size: 10Gi
+  database: schedule
+  username: postgres
+  password: postgres
+
+jwtSecret: CHANGEME
+
+rabbitmq:
+  enabled: true
+  host: rabbitmq
+  port: 5672
+  image: rabbitmq:3.13-management
+  username: user
+  password: password
+  persistence:
+    enabled: true
+    size: 10Gi
+
+serviceMonitor:
+  enabled: true
+
+pdb:
+  enabled: true
+  minAvailable: 1
+
+migrations:
+  enabled: true
+
+backup:
+  enabled: true
+  schedule: "0 3 * * *"
+  persistence:
+    enabled: true
+    size: 10Gi


### PR DESCRIPTION
## Summary
- add make tasks for helm deployment
- document Kubernetes troubleshooting runbook
- provide production values file for Helm chart
- reference Kubernetes docs in README files

## Testing
- `./backend/gradlew test --no-daemon`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684a1f3184e883269f54c5669ba627bc