### PR TITLE
Improve k8s chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,8 @@ helm upgrade --install schedule-app infra/k8s/helm/schedule-app \
 ```
 The cluster credentials must be provided in `KUBE_CONFIG_B64` and Docker images
 are pulled from the registry defined by `DOCKER_REPOSITORY`.
+Stateful components request CPU and memory limits via chart values so the
+cluster can schedule them with guaranteed resources.
 
 ### Проверка сервиса
 После деплоя убедитесь, что контейнеры запущены и перешли в состояние `healthy`:

--- a/docs/KUBERNETES_DESIGN.md
+++ b/docs/KUBERNETES_DESIGN.md
@@ -22,6 +22,8 @@ while keeping the deployment maintainable for the next 12–18 months.
 - **Jaeger** and **OpenTelemetry** for tracing.
 - **GitHub Actions** to build OCI images and run `helm upgrade --install`.
 - Containers run as non-root wherever possible to satisfy Pod Security policies.
+- Stateful services such as PostgreSQL and RabbitMQ request dedicated CPU and
+  memory resources to ensure reliable performance.
 
 ## Services
 

--- a/infra/k8s/helm/schedule-app/templates/postgresql-statefulset.yaml
+++ b/infra/k8s/helm/schedule-app/templates/postgresql-statefulset.yaml
@@ -29,6 +29,18 @@ spec:
                 secretKeyRef:
                   name: {{ include "schedule-app.fullname" . }}
                   key: postgres-password
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "pg_isready -U $POSTGRES_USER"]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "pg_isready -U $POSTGRES_USER"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.postgresql.resources | nindent 12 }}
           volumeMounts:
             - mountPath: /var/lib/postgresql/data
               name: data

--- a/infra/k8s/helm/schedule-app/templates/rabbitmq-statefulset.yaml
+++ b/infra/k8s/helm/schedule-app/templates/rabbitmq-statefulset.yaml
@@ -30,6 +30,18 @@ spec:
                 secretKeyRef:
                   name: {{ include "schedule-app.fullname" . }}
                   key: rabbitmq-password
+          livenessProbe:
+            exec:
+              command: ["rabbitmq-diagnostics", "-q", "ping"]
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["rabbitmq-diagnostics", "-q", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.rabbitmq.resources | nindent 12 }}
           volumeMounts:
             - mountPath: /var/lib/rabbitmq
               name: data

--- a/infra/k8s/helm/schedule-app/values-production.yaml
+++ b/infra/k8s/helm/schedule-app/values-production.yaml
@@ -58,6 +58,13 @@ postgresql:
   database: schedule
   username: postgres
   password: postgres
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "500m"
+    limits:
+      memory: "1Gi"
+      cpu: "1"
 
 jwtSecret: CHANGEME
 
@@ -71,6 +78,13 @@ rabbitmq:
   persistence:
     enabled: true
     size: 10Gi
+  resources:
+    requests:
+      memory: "512Mi"
+      cpu: "500m"
+    limits:
+      memory: "1Gi"
+      cpu: "1"
 
 serviceMonitor:
   enabled: true

--- a/infra/k8s/helm/schedule-app/values.yaml
+++ b/infra/k8s/helm/schedule-app/values.yaml
@@ -55,6 +55,13 @@ postgresql:
   database: schedule
   username: postgres
   password: postgres
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "250m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
 
 jwtSecret: secret
 
@@ -68,6 +75,13 @@ rabbitmq:
   persistence:
     enabled: true
     size: 1Gi
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "250m"
+    limits:
+      memory: "512Mi"
+      cpu: "500m"
 
 serviceMonitor:
   enabled: true


### PR DESCRIPTION
## Summary
- add resource requests and limits to Postgres and RabbitMQ
- expose liveness/readiness probes for stateful services
- update docs on Kubernetes design
- document new chart values in README

## Testing
- `npm --prefix frontend run lint`
- `./backend/gradlew -p backend test`


------
https://chatgpt.com/codex/tasks/task_e_684a259d88d08326844bf646d7ade147