### PR TITLE
Add Kubernetes service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ The cluster credentials must be provided in `KUBE_CONFIG_B64` and Docker images
 are pulled from the registry defined by `DOCKER_REPOSITORY`.
 Stateful components request CPU and memory limits via chart values so the
 cluster can schedule them with guaranteed resources.
+Each pod runs under its own ServiceAccount with tokens disabled by default
+to follow the least-privilege principle.
 
 ### Проверка сервиса
 После деплоя убедитесь, что контейнеры запущены и перешли в состояние `healthy`:

--- a/docs/KUBERNETES_DEPLOYMENT.md
+++ b/docs/KUBERNETES_DEPLOYMENT.md
@@ -20,4 +20,6 @@ The pipeline builds Docker images, pushes them to a registry and runs `helm upgr
 Adjust values in `infra/k8s/helm/schedule-app/values.yaml` for production before running the workflow.
 Set appropriate CPU and memory limits under the `resources` key so pods are scheduled with reserved capacity.
 A `Job` named `schedule-app-migrate` runs as a Helm hook before each installation or upgrade to apply database migrations. The job waits for the database and is cleaned up automatically after success.
+All pods use a dedicated service account created by the chart, unless a custom
+name is provided via `serviceAccount.name`.
 When `backup.enabled` is true the chart also provisions a `CronJob` that dumps the database every night using `pg_dump`.

--- a/docs/KUBERNETES_DESIGN.md
+++ b/docs/KUBERNETES_DESIGN.md
@@ -22,6 +22,7 @@ while keeping the deployment maintainable for the next 12–18 months.
 - **Jaeger** and **OpenTelemetry** for tracing.
 - **GitHub Actions** to build OCI images and run `helm upgrade --install`.
 - Containers run as non-root wherever possible to satisfy Pod Security policies.
+- Each pod uses its own ServiceAccount with tokens disabled by default.
 - Stateful services such as PostgreSQL and RabbitMQ request dedicated CPU and
   memory resources to ensure reliable performance.
 

--- a/infra/k8s/helm/schedule-app/README.md
+++ b/infra/k8s/helm/schedule-app/README.md
@@ -25,6 +25,7 @@ Values controlling credentials and connectivity:
 - `autoscaling.*` to tune or disable the Horizontal Pod Autoscaler
 - `serviceMonitor.enabled` to expose Prometheus metrics
 - `pdb.*` for the PodDisruptionBudget
+- `serviceAccount.*` to create or reuse a Kubernetes ServiceAccount
 - `jwtSecret` used by the backend
 - `resources` for the backend container requests and limits
 - `migrations.enabled` to run Flyway migrations via a pre-install and pre-upgrade Job

--- a/infra/k8s/helm/schedule-app/templates/_helpers.tpl
+++ b/infra/k8s/helm/schedule-app/templates/_helpers.tpl
@@ -1,3 +1,11 @@
 {{- define "schedule-app.fullname" -}}
 {{- printf "%s" .Release.Name -}}
 {{- end -}}
+
+{{- define "schedule-app.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "schedule-app.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/infra/k8s/helm/schedule-app/templates/backend-deployment.yaml
+++ b/infra/k8s/helm/schedule-app/templates/backend-deployment.yaml
@@ -12,6 +12,8 @@ spec:
       labels:
         app: {{ include "schedule-app.fullname" . }}-backend
     spec:
+      serviceAccountName: {{ include "schedule-app.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/infra/k8s/helm/schedule-app/templates/backup-cronjob.yaml
+++ b/infra/k8s/helm/schedule-app/templates/backup-cronjob.yaml
@@ -10,6 +10,8 @@ spec:
     spec:
       template:
         spec:
+          serviceAccountName: {{ include "schedule-app.serviceAccountName" . }}
+          automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
           restartPolicy: OnFailure
           containers:
             - name: backup

--- a/infra/k8s/helm/schedule-app/templates/migration-job.yaml
+++ b/infra/k8s/helm/schedule-app/templates/migration-job.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   template:
     spec:
+      serviceAccountName: {{ include "schedule-app.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
       restartPolicy: OnFailure
       ttlSecondsAfterFinished: 120
       containers:

--- a/infra/k8s/helm/schedule-app/templates/serviceaccount.yaml
+++ b/infra/k8s/helm/schedule-app/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "schedule-app.serviceAccountName" . }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/infra/k8s/helm/schedule-app/values-production.yaml
+++ b/infra/k8s/helm/schedule-app/values-production.yaml
@@ -30,6 +30,11 @@ containerSecurityContext:
   runAsNonRoot: true
   allowPrivilegeEscalation: false
 
+serviceAccount:
+  create: true
+  name: ""
+  automount: false
+
 service:
   type: ClusterIP
   port: 8080

--- a/infra/k8s/helm/schedule-app/values.yaml
+++ b/infra/k8s/helm/schedule-app/values.yaml
@@ -30,6 +30,11 @@ containerSecurityContext:
   runAsNonRoot: true
   allowPrivilegeEscalation: false
 
+serviceAccount:
+  create: true
+  name: ""
+  automount: false
+
 service:
   type: ClusterIP
   port: 8080


### PR DESCRIPTION
## Summary
- create a ServiceAccount in the Helm chart
- wire the account into Deployment, Job and CronJob
- document serviceAccount values and update design docs

## Testing
- `./backend/gradlew spotlessApply test`
- `npm ci`
- `npm run lint:fix`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a27521e0c83268bf1c5e67a5e0807