### PR TITLE
Add frontend deployment to Helm chart

### DIFF
--- a/.github/workflows/deploy-k8s.yml
+++ b/.github/workflows/deploy-k8s.yml
@@ -44,11 +44,13 @@ jobs:
         run: ./gradlew bootJar
         working-directory: backend
 
-      - name: Build Docker image
+      - name: Build Docker images
         run: |
           docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
           docker build -t "$DOCKER_REPOSITORY/schedule-backend:${GITHUB_SHA}" -f backend/Dockerfile .
           docker push "$DOCKER_REPOSITORY/schedule-backend:${GITHUB_SHA}"
+          docker build -t "$DOCKER_REPOSITORY/schedule-frontend:${GITHUB_SHA}" -f frontend/Dockerfile frontend
+          docker push "$DOCKER_REPOSITORY/schedule-frontend:${GITHUB_SHA}"
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -67,5 +69,7 @@ jobs:
           helm upgrade --install schedule-app infra/k8s/helm/schedule-app \
             --set image.repository=${{ secrets.DOCKER_REPOSITORY }}/schedule-backend \
             --set image.tag=${GITHUB_SHA} \
+            --set frontend.image=${{ secrets.DOCKER_REPOSITORY }}/schedule-frontend \
+            --set frontend.tag=${GITHUB_SHA} \
             --kubeconfig kubeconfig \
             --atomic --wait --timeout 5m

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,11 @@ frontend:
 	npm --prefix frontend run build
 
 k8s-deploy:
-	helm upgrade --install schedule-app infra/k8s/helm/schedule-app \
-		-f infra/k8s/helm/schedule-app/values.yaml \
-		--atomic --wait
+        helm upgrade --install schedule-app infra/k8s/helm/schedule-app \
+                -f infra/k8s/helm/schedule-app/values.yaml \
+                --set image.repository=${DOCKER_REPOSITORY}/schedule-backend \
+                --set frontend.image=${DOCKER_REPOSITORY}/schedule-frontend \
+                --atomic --wait
 
 k8s-delete:
 	helm uninstall schedule-app || true

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,13 @@
+# ---- Build stage ----
+FROM node:20 AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# ---- Runtime stage ----
+FROM nginx:1.27-alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "eslint . --fix",
     "test": "echo \"No frontend tests defined\"",
     "preview": "vite preview",
-    "postbuild": "cp -r dist/* ../backend/src/main/resources/static/"
+    "postbuild": "sh -c 'if [ -d ../backend/src/main/resources/static ]; then cp -r dist/* ../backend/src/main/resources/static/; fi'"
   },
   "dependencies": {
     "@fullcalendar/core": "^6.1.8",

--- a/infra/k8s/helm/schedule-app/README.md
+++ b/infra/k8s/helm/schedule-app/README.md
@@ -7,6 +7,7 @@ It targets Kubernetes clusters running version 1.30 or newer and follows the des
 The chart defines:
 
 - `Deployment` and `Service` for the Spring Boot backend
+- `Deployment` and `Service` for the React frontend
 - `StatefulSet` and `Service` for PostgreSQL
 - `StatefulSet` and `Service` for RabbitMQ
 - `Ingress` resource configured for the NGINX Ingress Controller
@@ -22,6 +23,7 @@ Values controlling credentials and connectivity:
 - `rabbitmq.host` / `rabbitmq.port`
 - `rabbitmq.username` / `rabbitmq.password`
 - `replicaCount` to set the default number of backend pods
+- `frontend.*` to configure the container image and resources for the React SPA
 - `autoscaling.*` to tune or disable the Horizontal Pod Autoscaler
 - `serviceMonitor.enabled` to expose Prometheus metrics
 - `pdb.*` for the PodDisruptionBudget
@@ -42,6 +44,8 @@ sample configuration is provided in `values-production.yaml`:
 
 ```bash
 helm upgrade --install schedule-app infra/k8s/helm/schedule-app \
-  --values infra/k8s/helm/schedule-app/values-production.yaml
+  --values infra/k8s/helm/schedule-app/values-production.yaml \
+  --set image.repository=<registry>/schedule-backend \
+  --set frontend.image=<registry>/schedule-frontend
 ```
 

--- a/infra/k8s/helm/schedule-app/templates/frontend-deployment.yaml
+++ b/infra/k8s/helm/schedule-app/templates/frontend-deployment.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.frontend.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "schedule-app.fullname" . }}-frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "schedule-app.fullname" . }}-frontend
+  template:
+    metadata:
+      labels:
+        app: {{ include "schedule-app.fullname" . }}-frontend
+    spec:
+      containers:
+        - name: frontend
+          image: {{ .Values.frontend.image }}:{{ .Values.frontend.tag }}
+          imagePullPolicy: {{ .Values.frontend.pullPolicy }}
+          ports:
+            - containerPort: 80
+          resources:
+            {{- toYaml .Values.frontend.resources | nindent 12 }}
+{{- end }}

--- a/infra/k8s/helm/schedule-app/templates/frontend-service.yaml
+++ b/infra/k8s/helm/schedule-app/templates/frontend-service.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.frontend.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "schedule-app.fullname" . }}-frontend
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ include "schedule-app.fullname" . }}-frontend
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http
+{{- end }}

--- a/infra/k8s/helm/schedule-app/templates/ingress.yaml
+++ b/infra/k8s/helm/schedule-app/templates/ingress.yaml
@@ -19,19 +19,24 @@ spec:
   {{- end }}
   {{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
-    - host: {{ .host }}
+    - host: {{ .Values.ingress.host }}
       http:
         paths:
-        {{- range .paths }}
-          - path: {{ .path }}
-            pathType: {{ .pathType }}
+        {{- if .Values.frontend.enabled }}
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "schedule-app.fullname" $ }}-frontend
+                port:
+                  number: 80
+        {{- end }}
+          - path: /api
+            pathType: Prefix
             backend:
               service:
                 name: {{ include "schedule-app.fullname" $ }}-backend
                 port:
                   number: {{ $.Values.service.port }}
-        {{- end }}
-  {{- end }}
 {{- end }}
 

--- a/infra/k8s/helm/schedule-app/values-production.yaml
+++ b/infra/k8s/helm/schedule-app/values-production.yaml
@@ -5,6 +5,19 @@ image:
 
 replicaCount: 3
 
+frontend:
+  image: schedule-frontend
+  tag: latest
+  pullPolicy: IfNotPresent
+  enabled: true
+  resources:
+    requests:
+      memory: "128Mi"
+      cpu: "100m"
+    limits:
+      memory: "256Mi"
+      cpu: "250m"
+
 autoscaling:
   enabled: true
   minReplicas: 3
@@ -42,11 +55,7 @@ service:
 ingress:
   enabled: true
   className: nginx
-  hosts:
-    - host: schedule.example.com
-      paths:
-        - path: /
-          pathType: Prefix
+  host: schedule.example.com
   tls:
     - secretName: schedule-tls
       hosts:

--- a/infra/k8s/helm/schedule-app/values.yaml
+++ b/infra/k8s/helm/schedule-app/values.yaml
@@ -5,6 +5,19 @@ image:
 
 replicaCount: 1
 
+frontend:
+  image: schedule-frontend
+  tag: latest
+  pullPolicy: IfNotPresent
+  enabled: true
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "50m"
+    limits:
+      memory: "128Mi"
+      cpu: "100m"
+
 autoscaling:
   enabled: true
   minReplicas: 1
@@ -42,11 +55,7 @@ service:
 ingress:
   enabled: true
   className: nginx
-  hosts:
-    - host: schedule.local
-      paths:
-        - path: /
-          pathType: Prefix
+  host: schedule.local
   tls: []
 
 postgresql:


### PR DESCRIPTION
## Summary
- add `frontend` build to Docker and Helm
- deploy frontend via `Ingress` root path
- adjust workflow and Makefile for new image
- avoid postbuild failure when packaging frontend

## Testing
- `./backend/gradlew test --no-daemon`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a295c552083268b0eb51138122b8f