### PR TITLE
Add frontend probes for Kubernetes

### DIFF
--- a/docs/KUBERNETES_DESIGN.md
+++ b/docs/KUBERNETES_DESIGN.md
@@ -25,6 +25,8 @@ while keeping the deployment maintainable for the next 12–18 months.
 - Each pod uses its own ServiceAccount with tokens disabled by default.
 - Stateful services such as PostgreSQL and RabbitMQ request dedicated CPU and
   memory resources to ensure reliable performance.
+- Application pods define liveness and readiness probes so Kubernetes can
+  quickly detect and replace unhealthy instances.
 
 ## Services
 

--- a/infra/k8s/helm/schedule-app/templates/frontend-deployment.yaml
+++ b/infra/k8s/helm/schedule-app/templates/frontend-deployment.yaml
@@ -19,6 +19,18 @@ spec:
           imagePullPolicy: {{ .Values.frontend.pullPolicy }}
           ports:
             - containerPort: 80
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 30
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
           resources:
             {{- toYaml .Values.frontend.resources | nindent 12 }}
 {{- end }}


### PR DESCRIPTION
## Summary
- add liveness/readiness probes for the frontend Deployment
- document that pods expose health checks

## Testing
- `./gradlew test` (backend)
- `npm run lint` (frontend)


------
https://chatgpt.com/codex/tasks/task_e_684a2d678e288326b4ce4f3777f16d3f