### PR TITLE
Update docs for Kubernetes rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,19 +192,18 @@ Each pod runs under its own ServiceAccount with tokens disabled by default
 to follow the least-privilege principle.
 
 ### Проверка сервиса
-После деплоя убедитесь, что контейнеры запущены и перешли в состояние `healthy`:
+После деплоя убедитесь, что все поды находятся в состоянии `Running` и
+готовы принимать трафик:
 ```bash
-docker compose ps -a
+kubectl get pods -n schedule
 ```
-Если сервис `app` отсутствует или имеет статус `Exited`, проверьте лог
-следующей командой:
+Если приложение не стартует, изучите журналы выбранного пода:
 ```bash
-docker compose logs app
+kubectl logs -n schedule deployment/schedule-app-backend
 ```
 Частая причина ошибки 502/503 — приложение не смогло подключиться к базе.
-Логи можно просмотреть командой `docker compose logs app` и при необходимости
-перезапустить инфраструктуру через `make up`. После проверки завершите работу
-командой `make down`.
+При необходимости выполните `helm rollback schedule-app <revision>` или
+переустановите релиз командой `helm upgrade --install`.
 
 Проверить здоровье приложения можно запросом к эндпоинту `/actuator/health`:
 ```bash

--- a/docs/NGINX_DEPLOYMENT.md
+++ b/docs/NGINX_DEPLOYMENT.md
@@ -19,7 +19,7 @@ Deployments start with one instance receiving a portion of traffic while the pre
 2. Frontend sources are linted with `eslint --fix` and checked for errors.
 3. The backend is built from the `backend/` directory using `./gradlew build`.
 4. The application JAR and rendered `nginx.conf` are copied to the VPS.
-5. `docker compose up -d` rebuilds containers.
+5. `helm upgrade --install schedule-app infra/k8s/helm/schedule-app --atomic --wait` deploys the new configuration.
 6. After success, traffic is gradually switched according to the strategy above.
 
 7. When all checks pass the pull request is auto-merged.

--- a/docs/NGINX_DESIGN.md
+++ b/docs/NGINX_DESIGN.md
@@ -2,10 +2,11 @@
 
 ## Target Architecture
 
-The solution runs inside Docker Compose. Traffic from clients first hits
-NGINX which proxies requests to the Spring Boot application. The
-application communicates with PostgreSQL. NGINX exposes its metrics via a
-Prometheus exporter container.
+Initially the solution ran inside Docker Compose. As part of the
+Kubernetes migration traffic now enters the cluster through the NGINX
+Ingress Controller which proxies requests to the Spring Boot backend. The
+application communicates with PostgreSQL while NGINX exposes metrics via a
+Prometheus exporter sidecar.
 
 ```
 Client ---> NGINX ---> App ---> PostgreSQL

--- a/docs/NGINX_HA.md
+++ b/docs/NGINX_HA.md
@@ -1,8 +1,9 @@
 # NGINX High Availability
 
 ## 8.1 Number of instances
-To meet the 99.9% availability target we run at least **two** NGINX containers.
-Traffic is distributed with an external load balancer or Docker Compose scaling.
+To meet the 99.9% availability target we run at least **two** NGINX
+instances. Traffic is distributed with an external load balancer or by
+scaling the Kubernetes Deployment.
 
 ## 8.2 Backend health checks
 Backends are configured in the `upstream` block with `max_fails=3` and


### PR DESCRIPTION
## Summary
- update README instructions for checking pods under Kubernetes
- refine NGINX design documentation
- clarify high availability section
- update deployment docs to use Helm

## Testing
- `./backend/gradlew test -p backend`
- `npm ci`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a2eb03b5c83268aa56326419eec49