### PR TITLE
Add helm lint to k8s pipeline

### DIFF
--- a/.github/workflows/deploy-k8s.yml
+++ b/.github/workflows/deploy-k8s.yml
@@ -64,6 +64,9 @@ jobs:
         env:
           KUBE_CONFIG_B64: ${{ secrets.KUBE_CONFIG_B64 }}
 
+      - name: Lint Helm chart
+        run: helm lint infra/k8s/helm/schedule-app
+
       - name: Deploy with Helm
         run: |
           helm upgrade --install schedule-app infra/k8s/helm/schedule-app \

--- a/docs/KUBERNETES_DEPLOYMENT.md
+++ b/docs/KUBERNETES_DEPLOYMENT.md
@@ -10,7 +10,8 @@ The pipeline builds Docker images, pushes them to a registry and runs `helm upgr
 2. On each push to `main` it builds the backend image using the provided Dockerfile.
 3. The image is tagged with the commit SHA and uploaded to the registry defined by `DOCKER_REPOSITORY`.
 4. Helm is configured using the kubeconfig stored in `KUBE_CONFIG_B64`.
-5. `helm upgrade --install` renders the chart from `infra/k8s/helm/schedule-app` with the new image tag. The command runs with `--atomic` and waits up to five minutes for rollout completion.
+5. `helm lint` verifies the chart before deployment to catch invalid manifests.
+6. `helm upgrade --install` renders the chart from `infra/k8s/helm/schedule-app` with the new image tag. The command runs with `--atomic` and waits up to five minutes for rollout completion.
 
 ## Required secrets
 


### PR DESCRIPTION
## Summary
- lint Helm chart before deploying in CI
- document helm lint step

## Testing
- `./gradlew test`
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a31cbbb448326a92978ce4c9ae93a