### PR TITLE
Improve Kubernetes chart configuration

### DIFF
--- a/docs/KUBERNETES_DESIGN.md
+++ b/docs/KUBERNETES_DESIGN.md
@@ -25,8 +25,10 @@ while keeping the deployment maintainable for the next 12–18 months.
 - Each pod uses its own ServiceAccount with tokens disabled by default.
 - Stateful services such as PostgreSQL and RabbitMQ request dedicated CPU and
   memory resources to ensure reliable performance.
-- Application pods define liveness and readiness probes so Kubernetes can
-  quickly detect and replace unhealthy instances.
+- Application pods define startup, liveness and readiness probes so
+  Kubernetes can detect slow or unhealthy instances.
+- Images are pulled using optional `imagePullSecrets` when the registry
+  requires authentication.
 
 ## Services
 

--- a/infra/k8s/helm/schedule-app/README.md
+++ b/infra/k8s/helm/schedule-app/README.md
@@ -28,6 +28,8 @@ Values controlling credentials and connectivity:
 - `serviceMonitor.enabled` to expose Prometheus metrics
 - `pdb.*` for the PodDisruptionBudget
 - `serviceAccount.*` to create or reuse a Kubernetes ServiceAccount
+- `imagePullSecrets` to reference Kubernetes secrets for pulling images
+- `startupProbe.*` to tune the startup probe for the backend
 - `jwtSecret` used by the backend
 - `resources` for the backend container requests and limits
 - `migrations.enabled` to run Flyway migrations via a pre-install and pre-upgrade Job

--- a/infra/k8s/helm/schedule-app/templates/backend-deployment.yaml
+++ b/infra/k8s/helm/schedule-app/templates/backend-deployment.yaml
@@ -14,6 +14,10 @@ spec:
     spec:
       serviceAccountName: {{ include "schedule-app.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -24,6 +28,15 @@ spec:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           ports:
             - containerPort: 8080
+          {{- if .Values.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /actuator/health

--- a/infra/k8s/helm/schedule-app/templates/frontend-deployment.yaml
+++ b/infra/k8s/helm/schedule-app/templates/frontend-deployment.yaml
@@ -13,6 +13,10 @@ spec:
       labels:
         app: {{ include "schedule-app.fullname" . }}-frontend
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       containers:
         - name: frontend
           image: {{ .Values.frontend.image }}:{{ .Values.frontend.tag }}

--- a/infra/k8s/helm/schedule-app/values-production.yaml
+++ b/infra/k8s/helm/schedule-app/values-production.yaml
@@ -2,6 +2,7 @@ image:
   repository: schedule-backend
   tag: latest
   pullPolicy: IfNotPresent
+imagePullSecrets: []
 
 replicaCount: 3
 
@@ -23,6 +24,12 @@ autoscaling:
   minReplicas: 3
   maxReplicas: 10
   targetCPUUtilizationPercentage: 75
+
+startupProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  failureThreshold: 30
 
 resources:
   requests:

--- a/infra/k8s/helm/schedule-app/values.yaml
+++ b/infra/k8s/helm/schedule-app/values.yaml
@@ -2,6 +2,7 @@ image:
   repository: schedule-backend
   tag: latest
   pullPolicy: IfNotPresent
+imagePullSecrets: []
 
 replicaCount: 1
 
@@ -23,6 +24,12 @@ autoscaling:
   minReplicas: 1
   maxReplicas: 5
   targetCPUUtilizationPercentage: 80
+
+startupProbe:
+  enabled: true
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  failureThreshold: 30
 
 resources:
   requests:


### PR DESCRIPTION
## Summary
- support imagePullSecrets in Helm chart
- add backend startup probe defaults
- document new values and design updates

## Testing
- `cd backend && ./gradlew test`
- `cd frontend && npm ci && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684a3327cad88326b7c8c376573a970b