### PR TITLE
Add network policies and graceful shutdown

### DIFF
--- a/docs/KUBERNETES_DESIGN.md
+++ b/docs/KUBERNETES_DESIGN.md
@@ -23,6 +23,8 @@ while keeping the deployment maintainable for the next 12–18 months.
 - **GitHub Actions** to build OCI images and run `helm upgrade --install`.
 - Containers run as non-root wherever possible to satisfy Pod Security policies.
 - Each pod uses its own ServiceAccount with tokens disabled by default.
+- NetworkPolicies restrict access to PostgreSQL and RabbitMQ so only backend
+  and maintenance jobs can connect.
 - Stateful services such as PostgreSQL and RabbitMQ request dedicated CPU and
   memory resources to ensure reliable performance.
 - Application pods define startup, liveness and readiness probes so

--- a/infra/k8s/helm/schedule-app/README.md
+++ b/infra/k8s/helm/schedule-app/README.md
@@ -38,6 +38,7 @@ Values controlling credentials and connectivity:
 - `backup.persistence.size` size of the PVC storing dumps
 - `migrations.resources` resource requests/limits for the Flyway Job
 - `backup.resources` resource requests/limits for the backup CronJob
+- `networkPolicy.enabled` to restrict database and RabbitMQ access to backend pods
 
 Environment variables consumed by the backend are stored in a ConfigMap
 generated from these values. Credentials remain in a Secret.

--- a/infra/k8s/helm/schedule-app/templates/backend-deployment.yaml
+++ b/infra/k8s/helm/schedule-app/templates/backend-deployment.yaml
@@ -18,6 +18,7 @@ spec:
       imagePullSecrets:
 {{ toYaml . | indent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: 30
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/infra/k8s/helm/schedule-app/templates/frontend-deployment.yaml
+++ b/infra/k8s/helm/schedule-app/templates/frontend-deployment.yaml
@@ -17,6 +17,7 @@ spec:
       imagePullSecrets:
 {{ toYaml . | indent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: 30
       containers:
         - name: frontend
           image: {{ .Values.frontend.image }}:{{ .Values.frontend.tag }}

--- a/infra/k8s/helm/schedule-app/templates/networkpolicy.yaml
+++ b/infra/k8s/helm/schedule-app/templates/networkpolicy.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "schedule-app.fullname" . }}-db
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ include "schedule-app.fullname" . }}-postgresql
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: {{ include "schedule-app.fullname" . }}-backend
+        - podSelector:
+            matchLabels:
+              job-name: {{ include "schedule-app.fullname" . }}-migrate
+        - podSelector:
+            matchLabels:
+              cronjob-name: {{ include "schedule-app.fullname" . }}-backup
+      ports:
+        - protocol: TCP
+          port: {{ .Values.postgresql.port }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "schedule-app.fullname" . }}-rabbitmq
+spec:
+  podSelector:
+    matchLabels:
+      app: {{ include "schedule-app.fullname" . }}-rabbitmq
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: {{ include "schedule-app.fullname" . }}-backend
+        - podSelector:
+            matchLabels:
+              job-name: {{ include "schedule-app.fullname" . }}-migrate
+      ports:
+        - protocol: TCP
+          port: {{ .Values.rabbitmq.port }}
+{{- end }}

--- a/infra/k8s/helm/schedule-app/values-production.yaml
+++ b/infra/k8s/helm/schedule-app/values-production.yaml
@@ -124,16 +124,19 @@ migrations:
       memory: "512Mi"
       cpu: "400m"
 
-backup:
-  enabled: true
-  schedule: "0 3 * * *"
-  persistence:
+  backup:
     enabled: true
-    size: 10Gi
-  resources:
-    requests:
-      memory: "256Mi"
-      cpu: "200m"
-    limits:
-      memory: "512Mi"
-      cpu: "400m"
+    schedule: "0 3 * * *"
+    persistence:
+      enabled: true
+      size: 10Gi
+    resources:
+      requests:
+        memory: "256Mi"
+        cpu: "200m"
+      limits:
+        memory: "512Mi"
+        cpu: "400m"
+
+networkPolicy:
+  enabled: true

--- a/infra/k8s/helm/schedule-app/values.yaml
+++ b/infra/k8s/helm/schedule-app/values.yaml
@@ -121,16 +121,19 @@ migrations:
       memory: "256Mi"
       cpu: "200m"
 
-backup:
-  enabled: false
-  schedule: "0 3 * * *"
-  persistence:
-    enabled: true
-    size: 1Gi
-  resources:
-    requests:
-      memory: "128Mi"
-      cpu: "100m"
-    limits:
-      memory: "256Mi"
-      cpu: "200m"
+  backup:
+    enabled: false
+    schedule: "0 3 * * *"
+    persistence:
+      enabled: true
+      size: 1Gi
+    resources:
+      requests:
+        memory: "128Mi"
+        cpu: "100m"
+      limits:
+        memory: "256Mi"
+        cpu: "200m"
+
+networkPolicy:
+  enabled: true


### PR DESCRIPTION
## Summary
- add terminationGracePeriodSeconds to backend and frontend deployments
- restrict PostgreSQL and RabbitMQ access using NetworkPolicies
- expose networkPolicy.enabled chart value
- document the new option in Helm README
- mention NetworkPolicies in the Kubernetes design

## Testing
- `./backend/gradlew test --no-daemon`
- `npm ci && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a35061ee483268ccc5b39012dcdf5