### PR TITLE
Add scheduling options for Helm chart

### DIFF
--- a/docs/KUBERNETES_DESIGN.md
+++ b/docs/KUBERNETES_DESIGN.md
@@ -34,6 +34,8 @@ while keeping the deployment maintainable for the next 12–18 months.
 - Each manifest applies the [Kubernetes recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)
   via the `schedule-app.labels` helper template so resources can be queried
   consistently.
+- Pods can be pinned to specific nodes via `nodeSelector`, `tolerations` and
+  `affinity` values exposed by the Helm chart.
 
 ## Services
 

--- a/infra/k8s/helm/schedule-app/README.md
+++ b/infra/k8s/helm/schedule-app/README.md
@@ -39,6 +39,9 @@ Values controlling credentials and connectivity:
 - `migrations.resources` resource requests/limits for the Flyway Job
 - `backup.resources` resource requests/limits for the backup CronJob
 - `networkPolicy.enabled` to restrict database and RabbitMQ access to backend pods
+- `nodeSelector` to pin pods to specific nodes
+- `tolerations` to schedule pods on tainted nodes
+- `affinity` rules for advanced scheduling
 
 Environment variables consumed by the backend are stored in a ConfigMap
 generated from these values. Credentials remain in a Secret.

--- a/infra/k8s/helm/schedule-app/templates/backend-deployment.yaml
+++ b/infra/k8s/helm/schedule-app/templates/backend-deployment.yaml
@@ -23,6 +23,18 @@ spec:
       imagePullSecrets:
 {{ toYaml . | indent 8 }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: 30
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/infra/k8s/helm/schedule-app/templates/backup-cronjob.yaml
+++ b/infra/k8s/helm/schedule-app/templates/backup-cronjob.yaml
@@ -19,6 +19,18 @@ spec:
         spec:
           serviceAccountName: {{ include "schedule-app.serviceAccountName" . }}
           automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+{{ toYaml . | indent 12 }}
+          {{- end }}
+          {{- with .Values.tolerations }}
+          tolerations:
+{{ toYaml . | indent 12 }}
+          {{- end }}
+          {{- with .Values.affinity }}
+          affinity:
+{{ toYaml . | indent 12 }}
+          {{- end }}
           restartPolicy: OnFailure
           containers:
             - name: backup

--- a/infra/k8s/helm/schedule-app/templates/frontend-deployment.yaml
+++ b/infra/k8s/helm/schedule-app/templates/frontend-deployment.yaml
@@ -22,6 +22,18 @@ spec:
       imagePullSecrets:
 {{ toYaml . | indent 8 }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: 30
       containers:
         - name: frontend

--- a/infra/k8s/helm/schedule-app/templates/migration-job.yaml
+++ b/infra/k8s/helm/schedule-app/templates/migration-job.yaml
@@ -18,6 +18,18 @@ spec:
     spec:
       serviceAccountName: {{ include "schedule-app.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       restartPolicy: OnFailure
       ttlSecondsAfterFinished: 120
       containers:

--- a/infra/k8s/helm/schedule-app/templates/postgresql-statefulset.yaml
+++ b/infra/k8s/helm/schedule-app/templates/postgresql-statefulset.yaml
@@ -19,6 +19,22 @@ spec:
         {{- include "schedule-app.labels" . | nindent 8 }}
         app.kubernetes.io/component: postgresql
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       containers:
         - name: postgres
           image: {{ .Values.postgresql.image }}

--- a/infra/k8s/helm/schedule-app/templates/rabbitmq-statefulset.yaml
+++ b/infra/k8s/helm/schedule-app/templates/rabbitmq-statefulset.yaml
@@ -19,6 +19,22 @@ spec:
         {{- include "schedule-app.labels" . | nindent 8 }}
         app.kubernetes.io/component: rabbitmq
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       containers:
         - name: rabbitmq
           image: {{ .Values.rabbitmq.image }}

--- a/infra/k8s/helm/schedule-app/values-production.yaml
+++ b/infra/k8s/helm/schedule-app/values-production.yaml
@@ -55,6 +55,10 @@ serviceAccount:
   name: ""
   automount: false
 
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
 service:
   type: ClusterIP
   port: 8080

--- a/infra/k8s/helm/schedule-app/values.yaml
+++ b/infra/k8s/helm/schedule-app/values.yaml
@@ -55,6 +55,10 @@ serviceAccount:
   name: ""
   automount: false
 
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
 service:
   type: ClusterIP
   port: 8080


### PR DESCRIPTION
## Summary
- expose nodeSelector, tolerations and affinity in values
- wire scheduling fields into all Helm templates
- document new options in chart README and design doc

## Testing
- `cd backend && ./gradlew test --no-daemon`
- `cd frontend && npm ci`
- `cd frontend && npm run lint`
- `cd frontend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a3933ec148326ba8cd6949b94745d