### PR TITLE
Add Terraform DB guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@
 ## Production Deployment
 
 Полный перечень переменных приведён в [docs/ENVIRONMENT.md](docs/ENVIRONMENT.md).
+Документация по развёртыванию PostgreSQL через Terraform
+находится в [docs/TERRAFORM_DB.md](docs/TERRAFORM_DB.md).
 
 1. При необходимости создайте файл `infra/.env` на основе переменных из
    [docs/ENVIRONMENT.md](docs/ENVIRONMENT.md). Значения для `POSTGRES_*` и других

--- a/docs/TERRAFORM_DB.md
+++ b/docs/TERRAFORM_DB.md
@@ -1,0 +1,46 @@
+# Provisioning PostgreSQL with Terraform
+
+This guide demonstrates how to create a production-grade PostgreSQL instance
+using reusable Terraform modules. The configuration assumes a Kubernetes
+cluster, but the same variables work for cloud providers as well.
+
+## Required variables
+
+| Name | Description |
+| --- | --- |
+| `db_name` | Name of the database to create |
+| `db_user` | Username that will own the database |
+| `storage_gb` | Size of the persistent volume in gigabytes |
+
+## Module example
+
+```hcl
+module "postgresql" {
+  source       = "terraform-module/postgresql/kubernetes"
+  version      = "1.0.0"
+
+  name         = var.db_name
+  username     = var.db_user
+  storage_size = var.storage_gb
+}
+
+output "db_host" {
+  value = module.postgresql.host
+}
+
+output "db_password" {
+  value     = module.postgresql.password
+  sensitive = true
+}
+```
+
+Run `terraform init` followed by `terraform apply` to provision the
+resources. After completion Terraform prints the connection details:
+
+```text
+db_host     = "postgresql.internal"
+db_password = "s3cr3t-password"
+```
+
+Save these values in `infra/.env` so the application can connect to the new
+instance.


### PR DESCRIPTION
## Summary
- document how to create the PostgreSQL instance with Terraform
- link the guide from the Production Deployment section

## Testing
- `./backend/gradlew test --no-daemon`
- `npm ci`
- `npm --prefix frontend ci`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684af6c6456483269f69dfe4daf11d11