### PR TITLE
Add RabbitMQ service

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,10 @@
    [docs/ENVIRONMENT.md](docs/ENVIRONMENT.md). Значения для `POSTGRES_*` и других
    переменных имеют безопасные defaults, поэтому файл можно опустить для локального
    запуска. Чтобы использовать собственный секрет, сгенерируйте `JWT_SECRET`,
-   например `openssl rand -hex 32`. `docker compose` автоматически считывает
-   `infra/.env`, а сам файл исключён из индекса Git.
+   например `openssl rand -hex 32`. По умолчанию RabbitMQ запускается c
+   `RABBITMQ_USER=user` и `RABBITMQ_PASSWORD=secret`, значения можно переопределить
+   в `infra/.env`. `docker compose` автоматически считывает этот файл, сам файл
+   исключён из индекса Git.
 2. Соберите production артефакты:
    ```bash
    npm --prefix frontend ci
@@ -120,6 +122,9 @@
    make down
    ```
 
+После запуска стек включает RabbitMQ. Панель управления доступна на
+`http://localhost:15672` под учётными данными из `infra/.env`.
+
 Перед повторным запуском остановите предыдущие контейнеры:
 
 ```bash
@@ -137,6 +142,9 @@ docker compose down --remove-orphans
 | `nginx`         | `80`, `443`     | `8080`, `8443` |
 | `nginx-exporter`| `9113`          | `9114`     |
 | `prometheus`    | `9090`          | `9090`     |
+| `rabbitmq`      | `5672`, `15672` | `5672`, `15672` |
+
+Веб-интерфейс RabbitMQ доступен на `http://localhost:15672`.
 
 Порты можно изменить, отредактировав Compose файлы в каталоге `infra/` или передав
 флаг `-p` при запуске `docker run`.

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -17,10 +17,10 @@ development.
 | `POSTGRES_DB` | `schedule` | `infra/docker-compose.yml` | `infra/.env` |
 | `POSTGRES_USER` | `postgres` | `infra/docker-compose.yml` | `infra/.env` |
 | `POSTGRES_PASSWORD` | `postgres` | `infra/docker-compose.yml` | `infra/.env` |
-| `RABBITMQ_HOST` | `rabbitmq` | `infra/k8s/helm/schedule-app/templates/backend-deployment.yaml` | chart values |
-| `RABBITMQ_PORT` | `5672` | `infra/k8s/helm/schedule-app/templates/backend-deployment.yaml` | chart values |
-| `RABBITMQ_USER` | `user` | `infra/k8s/helm/schedule-app/templates/rabbitmq-statefulset.yaml` | chart values |
-| `RABBITMQ_PASSWORD` | `secret` | `infra/k8s/helm/schedule-app/templates/rabbitmq-statefulset.yaml` | chart values |
+| `RABBITMQ_HOST` | `rabbitmq` | `infra/k8s/helm/schedule-app/templates/backend-deployment.yaml`, `infra/docker-compose.yml` | chart values, `infra/.env` |
+| `RABBITMQ_PORT` | `5672` | `infra/k8s/helm/schedule-app/templates/backend-deployment.yaml`, `infra/docker-compose.yml` | chart values, `infra/.env` |
+| `RABBITMQ_USER` | `user` | `infra/k8s/helm/schedule-app/templates/rabbitmq-statefulset.yaml`, `infra/docker-compose.yml` | chart values, `infra/.env` |
+| `RABBITMQ_PASSWORD` | `secret` | `infra/k8s/helm/schedule-app/templates/rabbitmq-statefulset.yaml`, `infra/docker-compose.yml` | chart values, `infra/.env` |
 | `SMTP_HOST` | `smtp.example.com` | `backend/src/main/resources/application.yml` | `infra/.env` or secrets |
 | `SMTP_PORT` | `587` | `backend/src/main/resources/application.yml` | `infra/.env` or secrets |
 | `SMTP_USERNAME` | `user@example.com` | `backend/src/main/resources/application.yml` | `infra/.env` or secrets |

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -8,3 +8,19 @@ services:
       - ./otel-collector-config.yml:/etc/otel-collector-config.yml:ro
     ports:
       - "4318:4318"
+
+  rabbitmq:
+    image: rabbitmq:3.13-management
+    env_file: ./.env
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER:-user}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD:-secret}
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- introduce RabbitMQ container
- document RABBITMQ_* variables
- mention management UI and default credentials

## Testing
- `./backend/gradlew test`
- `npm --prefix frontend run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684af7ffd0208326b60a1f476adb396c