### PR TITLE
Switch container registry to ghcr

### DIFF
--- a/.github/workflows/deploy-k8s.yml
+++ b/.github/workflows/deploy-k8s.yml
@@ -44,17 +44,19 @@ jobs:
         run: ./gradlew bootJar
         working-directory: backend
 
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build Docker images
         run: |
-          docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
-          docker build -t "$DOCKER_REPOSITORY/schedule-backend:${GITHUB_SHA}" -f backend/Dockerfile .
-          docker push "$DOCKER_REPOSITORY/schedule-backend:${GITHUB_SHA}"
-          docker build -t "$DOCKER_REPOSITORY/schedule-frontend:${GITHUB_SHA}" -f frontend/Dockerfile frontend
-          docker push "$DOCKER_REPOSITORY/schedule-frontend:${GITHUB_SHA}"
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          DOCKER_REPOSITORY: ${{ secrets.DOCKER_REPOSITORY }}
+          docker build -t ghcr.io/${{ github.repository }}/backend:${GITHUB_SHA} -f backend/Dockerfile .
+          docker push ghcr.io/${{ github.repository }}/backend:${GITHUB_SHA}
+          docker build -t ghcr.io/${{ github.repository }}/frontend:${GITHUB_SHA} -f frontend/Dockerfile frontend
+          docker push ghcr.io/${{ github.repository }}/frontend:${GITHUB_SHA}
 
       - name: Install Helm
         uses: azure/setup-helm@v3
@@ -70,9 +72,9 @@ jobs:
       - name: Deploy with Helm
         run: |
           helm upgrade --install schedule-app infra/k8s/helm/schedule-app \
-            --set image.repository=${{ secrets.DOCKER_REPOSITORY }}/schedule-backend \
+            --set image.repository=ghcr.io/${{ github.repository }}/backend \
             --set image.tag=${GITHUB_SHA} \
-            --set frontend.image=${{ secrets.DOCKER_REPOSITORY }}/schedule-frontend \
+            --set frontend.image=ghcr.io/${{ github.repository }}/frontend \
             --set frontend.tag=${GITHUB_SHA} \
             --kubeconfig kubeconfig \
             --atomic --wait --timeout 5m

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
 .PHONY: frontend k8s-deploy k8s-delete k8s-render
 
+REGISTRY ?= ghcr.io/idzumikatsu/trash
+
 frontend:
 	npm --prefix frontend run build
 
 k8s-deploy:
         helm upgrade --install schedule-app infra/k8s/helm/schedule-app \
                 -f infra/k8s/helm/schedule-app/values.yaml \
-                --set image.repository=${DOCKER_REPOSITORY}/schedule-backend \
-                --set frontend.image=${DOCKER_REPOSITORY}/schedule-frontend \
+                --set image.repository=$(REGISTRY)/backend \
+                --set frontend.image=$(REGISTRY)/frontend \
                 --atomic --wait
 
 k8s-delete:

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ helm upgrade --install schedule-app infra/k8s/helm/schedule-app \
   --atomic --wait --timeout 5m
 ```
 The cluster credentials must be provided in `KUBE_CONFIG_B64` and Docker images
-are pulled from the registry defined by `DOCKER_REPOSITORY`.
+are pulled from GitHub Container Registry.
 Stateful components request CPU and memory limits via chart values so the
 cluster can schedule them with guaranteed resources.
 Each pod runs under its own ServiceAccount with tokens disabled by default

--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -49,9 +49,6 @@ defaults (`8080` and `8443`) conflict with other services on the host. `NGINX_LO
 | `HTTPS_PROXY` | `http://proxy.example.com:8080` | `scripts/setup-proxy.sh` | shell |
 | `BACKUP_DIR` | `backups` | `scripts/backup-db.sh`, `infra/k8s/helm/schedule-app/templates/backup-cronjob.yaml` | shell |
 | `VITE_API_URL` |  | `frontend/src/api.ts` | `frontend/.env` |
-| `DOCKER_REPOSITORY` | `example/schedule` | `.github/workflows/deploy-k8s.yml` | secrets |
-| `DOCKER_USERNAME` | `dockeruser` | `.github/workflows/deploy-k8s.yml` | secrets |
-| `DOCKER_PASSWORD` | `secret` | `.github/workflows/deploy-k8s.yml` | secrets |
 | `KUBE_CONFIG_B64` | output of `base64 -w0 ~/.kube/config` | `.github/workflows/deploy-k8s.yml` | secrets |
 
 In production the frontend should leave `VITE_API_URL` empty because the base API path is already included in all fetch calls.

--- a/docs/KUBERNETES_DEPLOYMENT.md
+++ b/docs/KUBERNETES_DEPLOYMENT.md
@@ -8,15 +8,15 @@ The pipeline builds Docker images, pushes them to a registry and runs `helm upgr
 
 1. The workflow is defined in `.github/workflows/deploy-k8s.yml`.
 2. On each push to `main` it builds the backend image using the provided Dockerfile.
-3. The image is tagged with the commit SHA and uploaded to the registry defined by `DOCKER_REPOSITORY`.
+3. The image is tagged with the commit SHA and uploaded to GitHub Container Registry.
 4. Helm is configured using the kubeconfig stored in `KUBE_CONFIG_B64`.
 5. `helm lint` verifies the chart before deployment to catch invalid manifests.
 6. `helm upgrade --install` renders the chart from `infra/k8s/helm/schedule-app` with the new image tag. The command runs with `--atomic` and waits up to five minutes for rollout completion.
 
 ## Required secrets
 
-- `DOCKER_REPOSITORY`, `DOCKER_USERNAME`, `DOCKER_PASSWORD` – credentials for pushing images.
 - `KUBE_CONFIG_B64` – base64-encoded kubeconfig granting access to the cluster.
+No registry secrets are required because the workflow authenticates to GitHub Container Registry using the built-in `GITHUB_TOKEN`.
 
 Adjust values in `infra/k8s/helm/schedule-app/values.yaml` for production before running the workflow.
 Set appropriate CPU and memory limits under the `resources` key so pods are scheduled with reserved capacity.

--- a/infra/k8s/helm/schedule-app/values-production.yaml
+++ b/infra/k8s/helm/schedule-app/values-production.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: schedule-backend
+  repository: ghcr.io/idzumikatsu/trash/backend
   tag: latest
   pullPolicy: IfNotPresent
 imagePullSecrets: []
@@ -7,7 +7,7 @@ imagePullSecrets: []
 replicaCount: 3
 
 frontend:
-  image: schedule-frontend
+  image: ghcr.io/idzumikatsu/trash/frontend
   tag: latest
   pullPolicy: IfNotPresent
   enabled: true

--- a/infra/k8s/helm/schedule-app/values.yaml
+++ b/infra/k8s/helm/schedule-app/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: schedule-backend
+  repository: ghcr.io/idzumikatsu/trash/backend
   tag: latest
   pullPolicy: IfNotPresent
 imagePullSecrets: []
@@ -7,7 +7,7 @@ imagePullSecrets: []
 replicaCount: 1
 
 frontend:
-  image: schedule-frontend
+  image: ghcr.io/idzumikatsu/trash/frontend
   tag: latest
   pullPolicy: IfNotPresent
   enabled: true


### PR DESCRIPTION
## Summary
- publish Docker images to GitHub Container Registry
- update Helm values to pull images from ghcr.io
- drop obsolete Docker Hub secrets from documentation
- adjust example Makefile

## Testing
- `./backend/gradlew test`
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b8465b7648326b1eabbf6500783ed